### PR TITLE
fix: 設定ファイル破損時に正常起動しない #22

### DIFF
--- a/src/main/java/logbook/internal/ConfigReader.java
+++ b/src/main/java/logbook/internal/ConfigReader.java
@@ -41,7 +41,7 @@ final class ConfigReader<T> {
                     }
                 }
             }
-        } catch (IOException e) {
+        } catch (IOException | ArrayIndexOutOfBoundsException e) {
             this.getListener().exceptionThrown(e);
         }
         return instance;


### PR DESCRIPTION
https://github.com/sanaehirotaka/logbook-kai/issues/22

ArrayIndexOutOfBoundsExceptionをキャッチするように修正しました。
破損したXMLファイルが存在する状態で起動し、遠征時間等が表示されることを確認しました。