### PR TITLE
テーブルのソート順を保持

### DIFF
--- a/src/main/java/logbook/bean/AppConfig.java
+++ b/src/main/java/logbook/bean/AppConfig.java
@@ -3,6 +3,7 @@ package logbook.bean;
 import java.io.File;
 import java.io.Serializable;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -121,6 +122,9 @@ public final class AppConfig implements Serializable {
 
     /** テーブル列の幅 */
     private Map<String, Map<String, Double>> columnWidthMap = new HashMap<>();
+
+    /** テーブル列のソート順 */
+    private Map<String, List<String>> columnSortOrderMap = new HashMap<>();
 
     /** キャプチャの保存先 */
     private String captureDir;

--- a/src/main/java/logbook/internal/gui/TableTool.java
+++ b/src/main/java/logbook/internal/gui/TableTool.java
@@ -92,6 +92,7 @@ class TableTool {
     static void setVisible(TableView<?> table, String key) {
         Tools.Tables.setVisible(table, key);
         Tools.Tables.setWidth(table, key);
+        Tools.Tables.setSortOrder(table, key);
     }
 
 }

--- a/src/main/resources/logbook/gui/require_ndock.fxml
+++ b/src/main/resources/logbook/gui/require_ndock.fxml
@@ -9,7 +9,7 @@
    <children>
       <TableView fx:id="table" VBox.vgrow="ALWAYS">
         <columns>
-          <TableColumn fx:id="row" prefWidth="50.0" text="" />
+          <TableColumn fx:id="row" prefWidth="50.0" text="" sortable="false" />
           <TableColumn fx:id="id" prefWidth="50.0" text="ID" />
           <TableColumn fx:id="ship" prefWidth="260.0" text="艦娘" />
           <TableColumn fx:id="lv" prefWidth="50.0" text="Lv" />

--- a/src/main/resources/logbook/gui/ship_table.fxml
+++ b/src/main/resources/logbook/gui/ship_table.fxml
@@ -107,7 +107,7 @@
       </VBox>
       <TableView fx:id="table" cacheShape="false" VBox.vgrow="ALWAYS">
         <columns>
-          <TableColumn fx:id="row" prefWidth="50.0" text="" />
+          <TableColumn fx:id="row" prefWidth="50.0" text="" sortable="false" />
           <TableColumn fx:id="id" prefWidth="50.0" text="ID" />
           <TableColumn fx:id="ship" prefWidth="260.0" text="艦娘" />
           <TableColumn fx:id="type" prefWidth="75.0" text="艦種" />


### PR DESCRIPTION
Issue #32 に一部関連して、所有艦娘とお風呂に入りたい艦娘のテーブルのソート順を保存する変更をつくってみました。また PR #38 で導入していただいた行番号はソートの意味がないのでソートできなくする変更も作っております。ご検討のほどよろしくお願いいたします。