### PR TITLE
一覧における艦娘・装備画像の拡大・縮小オプション

### DIFF
--- a/src/main/java/logbook/bean/AppConfig.java
+++ b/src/main/java/logbook/bean/AppConfig.java
@@ -41,6 +41,9 @@ public final class AppConfig implements Serializable {
     /** 装備枠の空きがこれ以下でボタンを警告色に変える */
     private int itemFullyThreshold = 16;
 
+    /** 艦娘や装備の画像の拡大縮小割合(%) */
+    private int imageZoomRate = 100;
+
     /** 戦闘開始時に結果を反映 */
     private boolean applyBattle;
 

--- a/src/main/java/logbook/internal/gui/ConfigController.java
+++ b/src/main/java/logbook/internal/gui/ConfigController.java
@@ -68,6 +68,10 @@ public class ConfigController extends WindowController {
     @FXML
     private TextField itemFullyThreshold;
 
+    /** 画像拡大縮小割合(%) */
+    @FXML
+    private TextField imageZoomRate;
+
     /** 最前面に表示する */
     @FXML
     private CheckBox onTop;
@@ -152,6 +156,7 @@ public class ConfigController extends WindowController {
         this.applyResult.setSelected(conf.isApplyResult());
         this.shipFullyThreshold.setText(Integer.toString(conf.getShipFullyThreshold()));
         this.itemFullyThreshold.setText(Integer.toString(conf.getItemFullyThreshold()));
+        this.imageZoomRate.setText(Integer.toString(conf.getImageZoomRate()));
         this.onTop.setSelected(conf.isOnTop());
         this.checkDoit.setSelected(conf.isCheckDoit());
         this.checkUpdate.setSelected(conf.isCheckUpdate());
@@ -207,6 +212,7 @@ public class ConfigController extends WindowController {
         conf.setApplyResult(this.applyResult.isSelected());
         conf.setShipFullyThreshold(Integer.parseInt(this.shipFullyThreshold.getText()));
         conf.setItemFullyThreshold(Integer.parseInt(this.itemFullyThreshold.getText()));
+        conf.setImageZoomRate(Integer.parseInt(this.imageZoomRate.getText()));
         conf.setOnTop(this.onTop.isSelected());
         conf.setCheckDoit(this.checkDoit.isSelected());
         conf.setCheckUpdate(this.checkUpdate.isSelected());

--- a/src/main/java/logbook/internal/gui/ItemController.java
+++ b/src/main/java/logbook/internal/gui/ItemController.java
@@ -272,7 +272,7 @@ public class ItemController extends WindowController {
                         .get(itemId);
 
                 if (mst != null) {
-                    this.setGraphic(new ImageView(Items.itemImage(mst)));
+                    this.setGraphic(Tools.Conrtols.zoomImage(new ImageView(Items.itemImage(mst))));
                     this.setText(mst.getName());
                 }
             } else {
@@ -290,7 +290,7 @@ public class ItemController extends WindowController {
         protected void updateItem(Ship ship, boolean empty) {
             super.updateItem(ship, empty);
             if (!empty) {
-                this.setGraphic(new ImageView(Ships.shipWithItemImage(ship)));
+                this.setGraphic(Tools.Conrtols.zoomImage(new ImageView(Ships.shipWithItemImage(ship))));
                 if (ship != null) {
                     this.setText(Ships.toName(ship));
                 } else {

--- a/src/main/java/logbook/internal/gui/RequireNdockController.java
+++ b/src/main/java/logbook/internal/gui/RequireNdockController.java
@@ -192,7 +192,7 @@ public class RequireNdockController extends WindowController {
             super.updateItem(ship, empty);
 
             if (!empty) {
-                this.setGraphic(new ImageView(Ships.shipWithItemImage(ship)));
+                this.setGraphic(Tools.Conrtols.zoomImage(new ImageView(Ships.shipWithItemImage(ship))));
                 this.setText(Ships.shipMst(ship)
                         .map(ShipMst::getName)
                         .orElse(""));

--- a/src/main/java/logbook/internal/gui/ShipTablePane.java
+++ b/src/main/java/logbook/internal/gui/ShipTablePane.java
@@ -458,6 +458,7 @@ public class ShipTablePane extends VBox {
             this.table.setItems(sortedList);
             sortedList.comparatorProperty().bind(this.table.comparatorProperty());
             this.table.setOnKeyPressed(TableTool::defaultOnKeyPressedHandler);
+            this.table.setStyle("-fx-cell-size: 16px;");
             this.update();
         } catch (Exception e) {
             LoggerHolder.LOG.error("FXMLの初期化に失敗しました", e);
@@ -711,9 +712,9 @@ public class ShipTablePane extends VBox {
         @Override
         protected void updateItem(Ship ship, boolean empty) {
             super.updateItem(ship, empty);
-
+            
             if (!empty) {
-                this.setGraphic(new ImageView(Ships.shipWithItemImage(ship)));
+                this.setGraphic(Tools.Conrtols.zoomImage(new ImageView(Ships.shipWithItemImage(ship))));
                 this.setText(Ships.shipMst(ship)
                         .map(ShipMst::getName)
                         .orElse(""));
@@ -786,7 +787,7 @@ public class ShipTablePane extends VBox {
                             .filter(lv -> lv > 0)
                             .map(lv -> Messages.getString("item.level", lv)) //$NON-NLS-1$
                             .orElse(""));
-                    this.setGraphic(new ImageView(Items.itemImage(mst.get())));
+                    this.setGraphic(Tools.Conrtols.zoomImage(new ImageView(Items.itemImage(mst.get()))));
                     this.setText(text.toString());
                 } else {
                     this.setGraphic(null);

--- a/src/main/java/logbook/internal/gui/Tools.java
+++ b/src/main/java/logbook/internal/gui/Tools.java
@@ -31,6 +31,7 @@ import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.control.TextArea;
 import javafx.scene.image.Image;
+import javafx.scene.image.ImageView;
 import javafx.scene.image.WritableImage;
 import javafx.scene.input.Clipboard;
 import javafx.scene.input.ClipboardContent;
@@ -234,6 +235,22 @@ public class Tools {
                 notifications.show();
             }
         }
+        
+        /**
+         * 画像の拡大・縮小を行う
+         * @param view 拡大・縮小を行う画像を保持した {@link ImageView}
+         * @return 設定に従った拡大・縮小を行った画像を保持した {@link ImageView}
+         */
+        public static ImageView zoomImage(ImageView view) {
+            int percent = AppConfig.get().getImageZoomRate();
+            if (percent != 100 && percent > 0) {
+                double rate = (double)percent/100;
+                view.setFitHeight(view.getImage().getHeight()*rate);
+                view.setFitWidth(view.getImage().getWidth()*rate);
+            }
+            return view;
+        }
+
     }
 
     /**

--- a/src/main/resources/logbook/gui/config.fxml
+++ b/src/main/resources/logbook/gui/config.fxml
@@ -78,6 +78,9 @@
                               <TextField fx:id="itemFullyThreshold" prefWidth="60.0" GridPane.columnIndex="1" GridPane.rowIndex="3" />
                               <Label text="以下でボタン色を変更" GridPane.columnIndex="2" GridPane.rowIndex="3" />
                               <CheckBox fx:id="applyResult" mnemonicParsing="false" text="戦闘結果時に結果を反映" GridPane.columnSpan="2147483647" GridPane.rowIndex="1" />
+                              <Label text="画像の拡大・縮小(%)" GridPane.rowIndex="5" />
+                              <TextField fx:id="imageZoomRate" prefWidth="60.0" GridPane.columnIndex="1" GridPane.rowIndex="5" />
+                              <Label text="(一部の一覧表示にのみ適用)" GridPane.columnIndex="2" GridPane.rowIndex="5" />
                            </children>
                         </GridPane>
                      </children>


### PR DESCRIPTION
お世話になっております。こちらは Issue #27 に関連して、一覧のテーブルの表示行数を稼ぐために、せっかくのサムネイルをオフにするのではなく、縮小するオプションを実装してみました。（パーセントで入力するだけなので拡大もできることになるので、文言は「拡大・縮小」としています。）ご検討のほどよろしくお願いいたします。