### PR TITLE
艦娘一覧の行番号まわりの修正

### DIFF
--- a/src/main/java/logbook/internal/gui/ShipItem.java
+++ b/src/main/java/logbook/internal/gui/ShipItem.java
@@ -549,6 +549,7 @@ public class ShipItem {
                         .orElse(""))
                 .add(this.type.get())
                 .add(Integer.toString(this.lv.get()))
+                .add(Integer.toString(this.exp.get()))
                 .add(Integer.toString(this.cond.get()))
                 .add(this.label.get().stream().collect(Collectors.joining(",")))
                 .add(Integer.toString(this.seiku.get()))

--- a/src/main/java/logbook/internal/gui/Tools.java
+++ b/src/main/java/logbook/internal/gui/Tools.java
@@ -466,6 +466,7 @@ public class Tools {
             return table.getColumns()
                     .stream()
                     .map(TableColumn::getText)
+                    .filter(name -> !name.equals("行番号"))
                     .collect(Collectors.joining(separator));
         }
     }

--- a/src/main/resources/logbook/gui/require_ndock.fxml
+++ b/src/main/resources/logbook/gui/require_ndock.fxml
@@ -9,7 +9,7 @@
    <children>
       <TableView fx:id="table" VBox.vgrow="ALWAYS">
         <columns>
-          <TableColumn fx:id="row" prefWidth="50.0" text="" sortable="false" />
+          <TableColumn fx:id="row" prefWidth="50.0" text="行番号" sortable="false" />
           <TableColumn fx:id="id" prefWidth="50.0" text="ID" />
           <TableColumn fx:id="ship" prefWidth="260.0" text="艦娘" />
           <TableColumn fx:id="lv" prefWidth="50.0" text="Lv" />

--- a/src/main/resources/logbook/gui/ship_table.fxml
+++ b/src/main/resources/logbook/gui/ship_table.fxml
@@ -107,7 +107,7 @@
       </VBox>
       <TableView fx:id="table" cacheShape="false" VBox.vgrow="ALWAYS">
         <columns>
-          <TableColumn fx:id="row" prefWidth="50.0" text="" sortable="false" />
+          <TableColumn fx:id="row" prefWidth="50.0" text="行番号" sortable="false" />
           <TableColumn fx:id="id" prefWidth="50.0" text="ID" />
           <TableColumn fx:id="ship" prefWidth="260.0" text="艦娘" />
           <TableColumn fx:id="type" prefWidth="75.0" text="艦種" />


### PR DESCRIPTION
お世話になっております。先日の PR #38 に関連して、２つ問題を発見したので修正を作成してみました。ご検討のほどよろしくお願いします。

1. 列の表示・非表示を選択するとき、ラベルのないチェックボックスが表示される
#38 の実装時点では、行番号列のラベルは不要かなと思ってラベルを指定しなかったのですが、そのため列の表示・非表示のダイアログでも行番号列の選択用のチェックボックスがラベルのないチェックボックスとして表示されてしまっています。「行番号」という文字列を指定することで回避しています。

2. CSV出力がずれてしまう
行番号列はソートの影響を受けないという性格上 `ShipItem` の管理外の値になっているため、CSVには含まれませんが、CSVのタイトルはテーブルの `TableColumn` から生成されているためCSVに含まれ、結果として１行分ずれています。CSVに出力している時点で表計算ソフト側でも行番号は計算されていますし、CSVとして出力する必要がなさそうなので、タイトルから「行番号」列を抜くように変更しました。

ついでですが「exp」の列がCSVから抜けていたようなので追加しておきました。

もっとよい修正があればもちろんそちらのほうがよいので、その際は遠慮なくCloseしていただければと思います。よろしくお願いします。