### PR TITLE
艦娘一覧の表示項目を増やす

### DIFF
--- a/src/main/java/logbook/internal/gui/ShipItem.java
+++ b/src/main/java/logbook/internal/gui/ShipItem.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import java.util.StringJoiner;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.ObjectProperty;
@@ -21,6 +22,7 @@ import logbook.bean.ShipLabelCollection;
 import logbook.bean.ShipMst;
 import logbook.bean.SlotItem;
 import logbook.bean.SlotItemCollection;
+import logbook.bean.SlotitemMst;
 import logbook.bean.Stype;
 import logbook.internal.Items;
 import logbook.internal.SeaArea;
@@ -46,6 +48,9 @@ public class ShipItem {
 
     /** 経験値 */
     private IntegerProperty exp;
+    
+    /** Next */
+    private IntegerProperty next;
 
     /** cond */
     private IntegerProperty cond;
@@ -68,8 +73,29 @@ public class ShipItem {
     /** 対潜火力 */
     private IntegerProperty tPower;
 
+    /** 火力 */
+    private IntegerProperty karyoku;
+    
+    /** 雷装 */
+    private IntegerProperty raisou;
+    
+    /** 対空 */
+    private IntegerProperty taiku;
+    
+    /** 装甲 */
+    private IntegerProperty soukou;
+    
+    /** 回避 */
+    private IntegerProperty kaihi;
+    
     /** 対潜(素) */
     private IntegerProperty tais;
+
+    /** 索敵 */
+    private IntegerProperty sakuteki;
+    
+    /** 運 */
+    private IntegerProperty lucky;
 
     /** 装備1 */
     private IntegerProperty slot1;
@@ -204,6 +230,30 @@ public class ShipItem {
      */
     public void setExp(int exp) {
         this.exp = new SimpleIntegerProperty(exp);
+    }
+    
+    /**
+     * Nextを取得します。
+     * @return Next
+     */
+    public IntegerProperty nextProperty() {
+        return this.next;
+    }
+
+    /**
+     * Nextを取得します。
+     * @return Next
+     */
+    public int getNext() {
+        return this.next.get();
+    }
+
+    /**
+     * Nextを設定します。
+     * @param next Next
+     */
+    public void setNext(int next) {
+        this.next = new SimpleIntegerProperty(next);
     }
 
     /**
@@ -375,6 +425,126 @@ public class ShipItem {
     }
 
     /**
+     * 火力(素)を取得します。
+     * @return 火力(素)
+     */
+    public IntegerProperty karyokuProperty() {
+        return this.karyoku;
+    }
+
+    /**
+     * 火力(素)を取得します。
+     * @return 火力(素)
+     */
+    public int getKaryoku() {
+        return this.karyoku.get();
+    }
+
+    /**
+     * 火力(素)を設定します。
+     * @param karyoku 火力(素)
+     */
+    public void setKaryoku(int karyoku) {
+        this.karyoku = new SimpleIntegerProperty(karyoku);
+    }
+    
+    /**
+     * 雷装(素)を取得します。
+     * @return 雷装(素)
+     */
+    public IntegerProperty raisouProperty() {
+        return this.raisou;
+    }
+
+    /**
+     * 雷装(素)を取得します。
+     * @return 雷装(素)
+     */
+    public int getRaisou() {
+        return this.raisou.get();
+    }
+
+    /**
+     * 雷装(素)を設定します。
+     * @param raisou 雷装(素)
+     */
+    public void setRaisou(int raisou) {
+        this.raisou = new SimpleIntegerProperty(raisou);
+    }
+
+    /**
+     * 対空(素)を取得します。
+     * @return 対空(素)
+     */
+    public IntegerProperty taikuProperty() {
+        return this.taiku;
+    }
+
+    /**
+     * 対空(素)を取得します。
+     * @return 対空(素)
+     */
+    public int getTaiku() {
+        return this.taiku.get();
+    }
+
+    /**
+     * 対空(素)を設定します。
+     * @param taiku 対空(素)
+     */
+    public void setTaiku(int taiku) {
+        this.taiku = new SimpleIntegerProperty(taiku);
+    }
+
+    /**
+     * 装甲(素)を取得します。
+     * @return 装甲(素)
+     */
+    public IntegerProperty soukouProperty() {
+        return this.soukou;
+    }
+
+    /**
+     * 装甲(素)を取得します。
+     * @return 装甲(素)
+     */
+    public int getSoukou() {
+        return this.soukou.get();
+    }
+
+    /**
+     * 装甲(素)を設定します。
+     * @param soukou 装甲(素)
+     */
+    public void setSoukou(int soukou) {
+        this.soukou = new SimpleIntegerProperty(soukou);
+    }
+
+    /**
+     * 回避(素)を取得します。
+     * @return 回避(素)
+     */
+    public IntegerProperty kaihiProperty() {
+        return this.kaihi;
+    }
+
+    /**
+     * 回避(素)を取得します。
+     * @return 回避(素)
+     */
+    public int getKaihi() {
+        return this.kaihi.get();
+    }
+
+    /**
+     * 回避(素)を設定します。
+     * @param kaihi 回避(素)
+     */
+    public void setKaihi(int kaihi) {
+        this.kaihi = new SimpleIntegerProperty(kaihi);
+    }
+
+    /**
      * 対潜(素)を取得します。
      * @return 対潜(素)
      */
@@ -396,6 +566,54 @@ public class ShipItem {
      */
     public void setTais(int tais) {
         this.tais = new SimpleIntegerProperty(tais);
+    }
+
+    /**
+     * 索敵(素)を取得します。
+     * @return 索敵(素)
+     */
+    public IntegerProperty sakutekiProperty() {
+        return this.sakuteki;
+    }
+
+    /**
+     * 索敵(素)を取得します。
+     * @return 索敵(素)
+     */
+    public int getSakuteki() {
+        return this.sakuteki.get();
+    }
+
+    /**
+     * 索敵(素)を設定します。
+     * @param sakuteki 索敵(素)
+     */
+    public void setSakuteki(int sakuteki) {
+        this.sakuteki = new SimpleIntegerProperty(sakuteki);
+    }
+
+    /**
+     * 運(素)を取得します。
+     * @return 運(素)
+     */
+    public IntegerProperty luckyProperty() {
+        return this.lucky;
+    }
+
+    /**
+     * 運(素)を取得します。
+     * @return 運(素)
+     */
+    public int getLucky() {
+        return this.lucky.get();
+    }
+
+    /**
+     * 運(素)を設定します。
+     * @param lucky 運(素)
+     */
+    public void setLucky(int luckey) {
+        this.lucky = new SimpleIntegerProperty(luckey);
     }
 
     /**
@@ -550,6 +768,7 @@ public class ShipItem {
                 .add(this.type.get())
                 .add(Integer.toString(this.lv.get()))
                 .add(Integer.toString(this.exp.get()))
+                .add(Integer.toString(this.next.get()))
                 .add(Integer.toString(this.cond.get()))
                 .add(this.label.get().stream().collect(Collectors.joining(",")))
                 .add(Integer.toString(this.seiku.get()))
@@ -557,7 +776,14 @@ public class ShipItem {
                 .add(Integer.toString(this.rPower.get()))
                 .add(Integer.toString(this.yPower.get()))
                 .add(Integer.toString(this.tPower.get()))
+                .add(Integer.toString(this.karyoku.get()))
+                .add(Integer.toString(this.raisou.get()))
+                .add(Integer.toString(this.taiku.get()))
+                .add(Integer.toString(this.soukou.get()))
+                .add(Integer.toString(this.kaihi.get()))
                 .add(Integer.toString(this.tais.get()))
+                .add(Integer.toString(this.sakuteki.get()))
+                .add(Integer.toString(this.lucky.get()))
                 .add(slotItemName.apply(this.slot1.get()))
                 .add(slotItemName.apply(this.slot2.get()))
                 .add(slotItemName.apply(this.slot3.get()))
@@ -582,6 +808,7 @@ public class ShipItem {
         shipItem.setType(type);
         shipItem.setLv(ship.getLv());
         shipItem.setExp(ship.getExp().get(0));
+        shipItem.setNext(ship.getExp().get(1));
         shipItem.setCond(ship.getCond());
         Set<String> label = new LinkedHashSet<>();
         SeaArea area = SeaArea.fromArea(ship.getSallyArea());
@@ -602,16 +829,14 @@ public class ShipItem {
         shipItem.setyPower(Ships.yPower(ship));
         shipItem.settPower(Ships.tPower(ship));
 
-        Map<Integer, SlotItem> items = SlotItemCollection.get()
-                .getSlotitemMap();
-        int taisen = ship.getTaisen().get(0);
-        taisen = taisen - ship.getSlot()
-                .stream()
-                .map(items::get)
-                .map(Items::slotitemMst)
-                .mapToInt(e -> e.map(i -> i.getTais()).orElse(0))
-                .sum();
-        shipItem.setTais(taisen);
+        shipItem.setKaryoku(ship.getKaryoku().get(0) - sumItemParam(ship, i -> i.getHoug()));
+        shipItem.setRaisou(ship.getRaisou().get(0) - sumItemParam(ship, i -> i.getRaig()));
+        shipItem.setTaiku(ship.getTaiku().get(0) - sumItemParam(ship, i -> i.getTyku()));
+        shipItem.setSoukou(ship.getSoukou().get(0) - sumItemParam(ship, i -> i.getSouk()));
+        shipItem.setKaihi(ship.getKaihi().get(0) - sumItemParam(ship, i -> i.getHouk()));
+        shipItem.setTais(ship.getTaisen().get(0) - sumItemParam(ship, i -> i.getTais()));
+        shipItem.setSakuteki(ship.getSakuteki().get(0) - sumItemParam(ship, i -> i.getSaku()));
+        shipItem.setLucky(ship.getLucky().get(0) - sumItemParam(ship, i -> i.getLuck()));
 
         int slotNum = ship.getSlotnum();
         shipItem.setSlot1(ship.getSlot().get(0) == -1 && slotNum <= 0 ? 0 : ship.getSlot().get(0));
@@ -621,5 +846,20 @@ public class ShipItem {
         shipItem.setSlotEx(ship.getSlotEx());
 
         return shipItem;
+    }
+    
+    /**
+     * 装備のパラメータを合計する
+     * @param ship 艦娘
+     * @param mapper 合計するパラメータを返す mapper
+     * @return
+     */
+    private static int sumItemParam(Ship ship, Function<? super SlotitemMst, Integer> mapper) {
+        Map<Integer, SlotItem> items = SlotItemCollection.get().getSlotitemMap();
+        return Stream.concat(ship.getSlot().stream(), Stream.of(ship.getSlotEx()))
+        .map(items::get)
+        .map(Items::slotitemMst)
+        .mapToInt(e -> e.map(mapper).orElse(0))
+        .sum();
     }
 }

--- a/src/main/java/logbook/internal/gui/ShipTablePane.java
+++ b/src/main/java/logbook/internal/gui/ShipTablePane.java
@@ -218,6 +218,10 @@ public class ShipTablePane extends VBox {
     @FXML
     private TableColumn<ShipItem, Integer> exp;
 
+    /** Next */
+    @FXML
+    private TableColumn<ShipItem, Integer> next;
+
     /** cond */
     @FXML
     private TableColumn<ShipItem, Integer> cond;
@@ -246,9 +250,37 @@ public class ShipTablePane extends VBox {
     @FXML
     private TableColumn<ShipItem, Integer> tPower;
 
+    /** 火力(素) */
+    @FXML
+    private TableColumn<ShipItem, Integer> karyoku;
+
+    /** 雷装(素) */
+    @FXML
+    private TableColumn<ShipItem, Integer> raisou;
+
+    /** 対空(素) */
+    @FXML
+    private TableColumn<ShipItem, Integer> taiku;
+
+    /** 装甲(素) */
+    @FXML
+    private TableColumn<ShipItem, Integer> soukou;
+
+    /** 回避(素) */
+    @FXML
+    private TableColumn<ShipItem, Integer> kaihi;
+
     /** 対潜(素) */
     @FXML
     private TableColumn<ShipItem, Integer> tais;
+
+    /** 索敵(素) */
+    @FXML
+    private TableColumn<ShipItem, Integer> sakuteki;
+
+    /** 運(素) */
+    @FXML
+    private TableColumn<ShipItem, Integer> lucky;
 
     /** 装備1 */
     @FXML
@@ -432,6 +464,7 @@ public class ShipTablePane extends VBox {
             this.type.setCellValueFactory(new PropertyValueFactory<>("type"));
             this.lv.setCellValueFactory(new PropertyValueFactory<>("lv"));
             this.exp.setCellValueFactory(new PropertyValueFactory<>("exp"));
+            this.next.setCellValueFactory(new PropertyValueFactory<>("next"));
             this.cond.setCellFactory(p -> new CondCell());
             this.cond.setCellValueFactory(new PropertyValueFactory<>("cond"));
             this.label.setCellValueFactory(new PropertyValueFactory<>("label"));
@@ -441,7 +474,14 @@ public class ShipTablePane extends VBox {
             this.rPower.setCellValueFactory(new PropertyValueFactory<>("rPower"));
             this.yPower.setCellValueFactory(new PropertyValueFactory<>("yPower"));
             this.tPower.setCellValueFactory(new PropertyValueFactory<>("tPower"));
+            this.karyoku.setCellValueFactory(new PropertyValueFactory<>("karyoku"));
+            this.raisou.setCellValueFactory(new PropertyValueFactory<>("raisou"));
+            this.taiku.setCellValueFactory(new PropertyValueFactory<>("taiku"));
+            this.soukou.setCellValueFactory(new PropertyValueFactory<>("soukou"));
+            this.kaihi.setCellValueFactory(new PropertyValueFactory<>("kaihi"));
             this.tais.setCellValueFactory(new PropertyValueFactory<>("tais"));
+            this.sakuteki.setCellValueFactory(new PropertyValueFactory<>("sakuteki"));
+            this.lucky.setCellValueFactory(new PropertyValueFactory<>("lucky"));
             this.slot1.setCellValueFactory(new PropertyValueFactory<>("slot1"));
             this.slot1.setCellFactory(p -> new ItemImageCell());
             this.slot2.setCellValueFactory(new PropertyValueFactory<>("slot2"));

--- a/src/main/resources/logbook/gui/ship_table.fxml
+++ b/src/main/resources/logbook/gui/ship_table.fxml
@@ -113,6 +113,7 @@
           <TableColumn fx:id="type" prefWidth="75.0" text="艦種" />
           <TableColumn fx:id="lv" prefWidth="50.0" text="Lv" />
           <TableColumn fx:id="exp" prefWidth="60.0" text="exp" />
+          <TableColumn fx:id="next" prefWidth="60.0" text="next" />
           <TableColumn fx:id="cond" prefWidth="50.0" text="cond" />
           <TableColumn fx:id="label" prefWidth="100.0" text="ラベル" />
           <TableColumn fx:id="seiku" prefWidth="50.0" text="制空" />
@@ -120,7 +121,14 @@
           <TableColumn fx:id="rPower" prefWidth="60.0" text="雷戦火力" />
           <TableColumn fx:id="yPower" prefWidth="60.0" text="夜戦火力" />
           <TableColumn fx:id="tPower" prefWidth="60.0" text="対潜火力" />
+          <TableColumn fx:id="karyoku" prefWidth="60.0" text="火力(素)" />
+          <TableColumn fx:id="raisou" prefWidth="60.0" text="雷装(素)" />
+          <TableColumn fx:id="taiku" prefWidth="60.0" text="対空(素)" />
+          <TableColumn fx:id="soukou" prefWidth="60.0" text="装甲(素)" />
+          <TableColumn fx:id="kaihi" prefWidth="60.0" text="回避(素)" />
           <TableColumn fx:id="tais" prefWidth="60.0" text="対潜(素)" />
+          <TableColumn fx:id="sakuteki" prefWidth="60.0" text="索敵(素)" />
+          <TableColumn fx:id="lucky" prefWidth="60.0" text="運(素)" />
           <TableColumn fx:id="slot1" prefWidth="200.0" text="装備1" />
           <TableColumn fx:id="slot2" prefWidth="200.0" text="装備2" />
           <TableColumn fx:id="slot3" prefWidth="200.0" text="装備3" />


### PR DESCRIPTION
艦娘一覧で旧航海日誌にあってkaiにまだ未実装ないくつかの表示項目を実装するPRを作成してみました。既に実装済みの「対潜（素）」と同様、装備によるパラメータ変化を差し引いて素の値を出すようにしています。実装したパラメータは
- 火力
- 雷装
- 対空
- 装甲
- 回避
- 索敵
- 運

になります。また、 Issue #32 に経験値のNext値の表示要望がありましたのでこれも追加しています。ご検討のほどよろしくお願いいたします。