### PR TITLE
任意に更新確認する機能

### DIFF
--- a/src/main/java/logbook/internal/CheckUpdate.java
+++ b/src/main/java/logbook/internal/CheckUpdate.java
@@ -28,6 +28,10 @@ public class CheckUpdate {
     };
 
     public static void run() {
+        CheckUpdate.run(false);
+    }
+
+    public static void run(Boolean isStartUp) {
         for (String checkSite : CHECK_SITES) {
             URI uri = URI.create(checkSite);
 
@@ -39,7 +43,14 @@ public class CheckUpdate {
                 Version newversion = new Version(str);
 
                 if (Version.getCurrent().compareTo(newversion) < 0) {
-                    Platform.runLater(() -> CheckUpdate.openInfo(Version.getCurrent(), newversion));
+                    Platform.runLater(() -> CheckUpdate.openInfo(Version.getCurrent(), newversion, isStartUp));
+                } else if (!isStartUp) {
+                    Alert alert = new Alert(AlertType.INFORMATION);
+                    alert.setTitle("更新の確認");
+                    alert.setContentText("最新のバージョンです");
+                    alert.getButtonTypes().clear();
+                    alert.getButtonTypes().addAll(ButtonType.OK);
+                    alert.showAndWait();
                 }
                 break;
             } catch (Exception e) {
@@ -48,11 +59,13 @@ public class CheckUpdate {
         }
     }
 
-    private static void openInfo(Version o, Version n) {
+    private static void openInfo(Version o, Version n, Boolean isStartUp) {
         String message = "新しいバージョンがあります。ダウンロードサイトを開きますか？\n"
                 + "現在のバージョン:" + o + "\n"
-                + "新しいバージョン:" + n + "\n"
-                + "※自動アップデートチェックは[その他]-[設定]から無効に出来ます";
+                + "新しいバージョン:" + n;
+        if (isStartUp) {
+            message += "\n※自動アップデートチェックは[その他]-[設定]から無効に出来ます";
+        }
 
         ButtonType update = new ButtonType("自動更新");
         ButtonType visible = new ButtonType("ダウンロードサイトを開く");

--- a/src/main/java/logbook/internal/CheckUpdate.java
+++ b/src/main/java/logbook/internal/CheckUpdate.java
@@ -15,6 +15,9 @@ import javafx.application.Platform;
 import javafx.scene.control.Alert;
 import javafx.scene.control.Alert.AlertType;
 import javafx.scene.control.ButtonType;
+import javafx.stage.Stage;
+
+import logbook.internal.gui.Tools;
 
 /**
  * アップデートチェック
@@ -27,11 +30,15 @@ public class CheckUpdate {
             "http://kancolle.sanaechan.net/logbook-kai.txt"
     };
 
-    public static void run() {
-        CheckUpdate.run(false);
+    public static void run(Stage stage) {
+        CheckUpdate.run(false, stage);
     }
 
-    public static void run(Boolean isStartUp) {
+    public static void run(boolean isStartUp) {
+        CheckUpdate.run(isStartUp, null);
+    }
+
+    private static void run(boolean isStartUp, Stage stage) {
         for (String checkSite : CHECK_SITES) {
             URI uri = URI.create(checkSite);
 
@@ -43,14 +50,9 @@ public class CheckUpdate {
                 Version newversion = new Version(str);
 
                 if (Version.getCurrent().compareTo(newversion) < 0) {
-                    Platform.runLater(() -> CheckUpdate.openInfo(Version.getCurrent(), newversion, isStartUp));
+                    Platform.runLater(() -> CheckUpdate.openInfo(Version.getCurrent(), newversion, isStartUp, stage));
                 } else if (!isStartUp) {
-                    Alert alert = new Alert(AlertType.INFORMATION);
-                    alert.setTitle("更新の確認");
-                    alert.setContentText("最新のバージョンです");
-                    alert.getButtonTypes().clear();
-                    alert.getButtonTypes().addAll(ButtonType.OK);
-                    alert.showAndWait();
+                    Tools.Conrtols.alert(AlertType.INFORMATION, "更新の確認", "最新のバージョンです", stage);
                 }
                 break;
             } catch (Exception e) {
@@ -59,7 +61,7 @@ public class CheckUpdate {
         }
     }
 
-    private static void openInfo(Version o, Version n, Boolean isStartUp) {
+    private static void openInfo(Version o, Version n, boolean isStartUp, Stage stage) {
         String message = "新しいバージョンがあります。ダウンロードサイトを開きますか？\n"
                 + "現在のバージョン:" + o + "\n"
                 + "新しいバージョン:" + n;
@@ -75,6 +77,7 @@ public class CheckUpdate {
         alert.setTitle("新しいバージョン");
         alert.setHeaderText("新しいバージョン");
         alert.setContentText(message);
+        alert.initOwner(stage);
         alert.getButtonTypes().clear();
         alert.getButtonTypes().addAll(update, visible, no);
         Optional<ButtonType> result = alert.showAndWait();

--- a/src/main/java/logbook/internal/CheckUpdate.java
+++ b/src/main/java/logbook/internal/CheckUpdate.java
@@ -15,25 +15,19 @@ import javafx.application.Platform;
 import javafx.scene.control.Alert;
 import javafx.scene.control.Alert.AlertType;
 import javafx.scene.control.ButtonType;
-import logbook.bean.AppConfig;
-import logbook.plugin.lifecycle.StartUp;
 
 /**
  * アップデートチェック
  *
  */
-public class CheckUpdate implements StartUp {
+public class CheckUpdate {
 
     private static final String[] CHECK_SITES = {
             "https://kancolle.sanaechan.net/logbook-kai.txt",
             "http://kancolle.sanaechan.net/logbook-kai.txt"
     };
 
-    @Override
-    public void run() {
-        if (!AppConfig.get().isCheckUpdate()) {
-            return;
-        }
+    public static void run() {
         for (String checkSite : CHECK_SITES) {
             URI uri = URI.create(checkSite);
 

--- a/src/main/java/logbook/internal/CheckUpdateStartUp.java
+++ b/src/main/java/logbook/internal/CheckUpdateStartUp.java
@@ -1,0 +1,20 @@
+package logbook.internal;
+
+import logbook.bean.AppConfig;
+import logbook.plugin.lifecycle.StartUp;
+
+/**
+ * アップデートチェック
+ *
+ */
+public class CheckUpdateStartUp implements StartUp {
+
+    @Override
+    public void run() {
+        if (!AppConfig.get().isCheckUpdate()) {
+            return;
+        }
+
+        CheckUpdate.run();
+    }
+}

--- a/src/main/java/logbook/internal/CheckUpdateStartUp.java
+++ b/src/main/java/logbook/internal/CheckUpdateStartUp.java
@@ -15,6 +15,6 @@ public class CheckUpdateStartUp implements StartUp {
             return;
         }
 
-        CheckUpdate.run();
+        CheckUpdate.run(true);
     }
 }

--- a/src/main/java/logbook/internal/gui/MainController.java
+++ b/src/main/java/logbook/internal/gui/MainController.java
@@ -46,6 +46,7 @@ import logbook.internal.Audios;
 import logbook.internal.LoggerHolder;
 import logbook.internal.Ships;
 import logbook.internal.proxy.ProxyHolder;
+import logbook.internal.CheckUpdate;
 import logbook.plugin.PluginServices;
 import logbook.plugin.gui.MainCalcMenu;
 import logbook.plugin.gui.MainCommandMenu;
@@ -361,6 +362,20 @@ public class MainController extends WindowController {
             InternalFXMLLoader.showWindow("logbook/gui/config.fxml", this.getWindow(), "設定");
         } catch (Exception ex) {
             LoggerHolder.get().error("設定の初期化に失敗しました", ex);
+        }
+    }
+
+    /**
+     * 更新を確認
+     *
+     * @param e ActionEvent
+     */
+    @FXML
+    void updateCheck(ActionEvent e) {
+        try {
+            CheckUpdate.run();
+        } catch (Exception ex) {
+            LoggerHolder.get().error("更新情報の取得に失敗しました", ex);
         }
     }
 

--- a/src/main/java/logbook/internal/gui/MainController.java
+++ b/src/main/java/logbook/internal/gui/MainController.java
@@ -373,7 +373,7 @@ public class MainController extends WindowController {
     @FXML
     void updateCheck(ActionEvent e) {
         try {
-            CheckUpdate.run();
+            CheckUpdate.run(this.getWindow());
         } catch (Exception ex) {
             LoggerHolder.get().error("更新情報の取得に失敗しました", ex);
         }

--- a/src/main/resources/META-INF/services/logbook.plugin.lifecycle.StartUp
+++ b/src/main/resources/META-INF/services/logbook.plugin.lifecycle.StartUp
@@ -1,1 +1,1 @@
-logbook.internal.CheckUpdate
+logbook.internal.CheckUpdateStartUp

--- a/src/main/resources/logbook/gui/main.fxml
+++ b/src/main/resources/logbook/gui/main.fxml
@@ -71,6 +71,7 @@
                      <accelerator>
                         <KeyCodeCombination alt="UP" code="COMMA" control="UP" meta="UP" shift="UP" shortcut="DOWN" />
                      </accelerator></MenuItem>
+                  <MenuItem mnemonicParsing="false" onAction="#updateCheck" text="更新を確認" />
                   <MenuItem mnemonicParsing="false" onAction="#version" text="バージョン情報" />
             </items>
           </Menu>


### PR DESCRIPTION
航海日誌を再起動することなく更新確認する機能が欲しくなったので[その他]から実行できるように