### PR TITLE
入渠ドックが更新されたとき艦娘の情報も更新

### DIFF
--- a/src/main/java/logbook/internal/gui/FleetTabPane.java
+++ b/src/main/java/logbook/internal/gui/FleetTabPane.java
@@ -25,6 +25,7 @@ import javafx.scene.image.ImageView;
 import javafx.scene.layout.VBox;
 import logbook.bean.AppCondition;
 import logbook.bean.DeckPort;
+import logbook.bean.NdockCollection;
 import logbook.bean.Ship;
 import logbook.bean.ShipCollection;
 import logbook.bean.ShipMst;
@@ -51,6 +52,9 @@ public class FleetTabPane extends ScrollPane {
 
     /** 艦娘達のハッシュ・コード */
     private int shipsHashCode;
+
+    /** 入渠中の艦娘達のハッシュ・コード */
+    private int ndocksHashCode;
 
     /** Tabのクラス名(タブ色を変えるのに使用) */
     private String tabCssClass;
@@ -182,11 +186,15 @@ public class FleetTabPane extends ScrollPane {
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
 
-        if (this.portHashCode != this.port.hashCode() || this.shipsHashCode != this.shipList.hashCode()) {
+        int ndocksHashCode = NdockCollection.get().getNdockSet().hashCode();
+
+        if (this.portHashCode != this.port.hashCode() || this.shipsHashCode != this.shipList.hashCode()
+                || this.ndocksHashCode != ndocksHashCode) {
             this.updateShips();
         }
         this.portHashCode = this.port.hashCode();
         this.shipsHashCode = this.shipList.hashCode();
+        this.ndocksHashCode = ndocksHashCode;
     }
 
     /**


### PR DESCRIPTION
艦娘を入渠させたときに、何か更新のトリガーがかかるまで航海日誌上の表示が変わらないので変わるようにする変更です。（`FleetTabPane.java`）

あともう一つはAPIの仕様上の問題ではありますが、入渠中の艦娘が修理完了（完了予定時刻１分前以降）の状態で入渠に移動すると、艦これ上では編成等で入渠表示だった艦娘が通常状態に戻りますが、航海日誌上は同様に更新されない上に所有艦娘等でもダメージ状態になったままなのを補正する変更です。（`ApiGetMemberNdock.java`）

ご検討いただけると嬉しいです。よろしくお願いします。