### PR TITLE
艦娘がいないところへドラッグ&ドロップした時の挙動修正

### DIFF
--- a/src/main/java/logbook/api/ApiReqHenseiChange.java
+++ b/src/main/java/logbook/api/ApiReqHenseiChange.java
@@ -63,6 +63,7 @@ public class ApiReqHenseiChange implements APIListenerSpi {
                     if (from == -1) {
                         ships2.removeIf(id -> id.equals(shipId));
                         ships2.add(-1);
+                        shipIdx = deckMap.get(portId).getShip().indexOf(-1);
                     } else {
                         ships2.set(ships2.indexOf(shipId), from);
                     }


### PR DESCRIPTION
編成画面で艦娘のいない枠にドラッグ&ドロップした際に、航海日誌上の艦隊から艦娘が消えたり順番がおかしくなったりするバグを修正しました