### PR TITLE
海戦・ドロップ報告書 書き込み時のバグ修正

### DIFF
--- a/src/main/java/logbook/internal/log/BattleResultLogFormat.java
+++ b/src/main/java/logbook/internal/log/BattleResultLogFormat.java
@@ -160,7 +160,7 @@ public class BattleResultLogFormat extends LogFormatBase<BattleLog> {
         // ドロップ艦娘
         joiner.add(Optional.ofNullable(result.getGetShip()).map(BattleResult.GetShip::getShipName).orElse(""));
         // 味方艦
-        if (log.getCombinedType() == CombinedType.未結成) {
+        if (log.getCombinedType() == CombinedType.未結成 || battle.getDockId() > 2) {
             // 通常艦隊はDockIdの艦隊
             List<Ship> friendFleet = log.getDeckMap().get(battle.getDockId());
             for (int i = 0; i < 12; i++) {


### PR DESCRIPTION
#112 にて、連合艦隊編成時に第三or第四艦隊で出撃したさい、NullPointExceptionがおきるバグがありましたので、パッチをPRします。