### PR TITLE
対空噴進弾幕発動率を艦隊ポップアップで表示する

### DIFF
--- a/src/main/java/logbook/internal/Ships.java
+++ b/src/main/java/logbook/internal/Ships.java
@@ -62,6 +62,10 @@ public class Ships {
     private static final Map<SlotItemType, Double> VIEW_COEFFICIENT = new EnumMap<>(SlotItemType.class);
     /** 改修係数 */
     private static final Map<SlotItemType, Double> LV_COEFFICIENT = new EnumMap<>(SlotItemType.class);
+    /** 対空係数 */
+    private static final Map<SlotItemType, Double> AA_COEFFICIENT = new EnumMap<>(SlotItemType.class);
+    /** 対空改修係数 */
+    private static final Map<SlotItemType, Double> AALV_COEFFICIENT = new EnumMap<>(SlotItemType.class);
 
     static {
         // 索敵係数
@@ -113,6 +117,26 @@ public class Ships {
         LV_COEFFICIENT.put(SlotItemType.大型電探, 1.25D);
         // 水上偵察機：1.2
         LV_COEFFICIENT.put(SlotItemType.水上偵察機, 1.2D);
+
+        // 対空係数
+        // 対空機銃：6
+        AA_COEFFICIENT.put(SlotItemType.対空機銃, 6D);
+        // 高角砲・高射装置：4
+        AA_COEFFICIENT.put(SlotItemType.小口径主砲, 4D);
+        AA_COEFFICIENT.put(SlotItemType.副砲, 4D);
+        AA_COEFFICIENT.put(SlotItemType.高射装置, 4D);
+        // 対空電探：3
+        AA_COEFFICIENT.put(SlotItemType.小型電探, 3D);
+        AA_COEFFICIENT.put(SlotItemType.大型電探, 3D);
+        AA_COEFFICIENT.put(SlotItemType.大型電探II, 3D);
+
+        // 対空改修係数
+        // 機銃：4
+        AALV_COEFFICIENT.put(SlotItemType.対空機銃, 4D);
+        // 高角砲・高射装置：2
+        AALV_COEFFICIENT.put(SlotItemType.小口径主砲, 2D);
+        AALV_COEFFICIENT.put(SlotItemType.副砲, 2D);
+        AALV_COEFFICIENT.put(SlotItemType.高射装置, 2D);
     }
 
     private Ships() {

--- a/src/main/java/logbook/internal/Ships.java
+++ b/src/main/java/logbook/internal/Ships.java
@@ -634,6 +634,62 @@ public class Ships {
     }
 
     /**
+     * 対空噴進弾幕発動率
+     *
+     * @param ship 艦娘
+     * @return 噴進弾幕発動率
+     */
+    public static double rocketBarrageActivationRate(Ship ship) {
+        List<SlotitemMst> items = getSlotitemMst(ship).collect(Collectors.toList());
+        SlotItem exItem = SlotItemCollection.get()
+                .getSlotitemMap()
+                .get(ship.getSlotEx());
+        if (exItem != null) {
+            SlotitemMst exItemMst = SlotitemMstCollection.get()
+                    .getSlotitemMap()
+                    .get(exItem.getSlotitemId());
+            items.add(exItemMst);
+        }
+        long rocketCount = items.stream()
+                .filter(e -> e.getId() == 274) // 噴進砲改二
+                .count();
+        if (rocketCount == 0) return 0D;
+
+        boolean canRocketBarrage = shipMst(ship)
+                .map(ShipMst::getStype)
+                .map(stype -> ShipType.水上機母艦.equals(stype)
+                        || ShipType.航空巡洋艦.equals(stype)
+                        || ShipType.航空戦艦.equals(stype)
+                        || ShipType.軽空母.equals(stype)
+                        || ShipType.正規空母.equals(stype)
+                        || ShipType.装甲空母.equals(stype))
+                .orElse(false);
+        if (!canRocketBarrage) return 0D;
+
+        double bonus = 0D;
+
+        if (rocketCount > 1) bonus += 15D;
+
+        Integer shipMstId = shipMst(ship)
+                .map(ShipMst::getId)
+                .orElse(0);
+        List<Integer> iseClass = new ArrayList<Integer>();
+        iseClass.add(82); // 伊勢改
+        iseClass.add(553); // 伊勢改二
+        iseClass.add(88); // 日向改
+
+        if (iseClass.contains(shipMstId)) bonus += 25D;
+
+        int antiAircraft = (int)Math.floor(weightAntiAircraft(ship));
+        if (antiAircraft % 2 != 0) antiAircraft -= 1;
+
+        double baseActivationRate = (antiAircraft + ship.getLucky().get(0)) / 282D;
+        double activationRate = Math.floor(baseActivationRate * 1000) / 10;
+
+        return activationRate + bonus;
+    }
+
+    /**
      * 判定式(33)
      *
      * @param ships 艦娘達

--- a/src/main/java/logbook/internal/gui/FleetTabShipPopup.java
+++ b/src/main/java/logbook/internal/gui/FleetTabShipPopup.java
@@ -61,6 +61,14 @@ public class FleetTabShipPopup extends VBox {
                     this.getChildren().add(new FleetTabShipPopupItem(this.chara));
                 }
             }
+            double barrageRate = Ships.rocketBarrageActivationRate(ship);
+            if (barrageRate != 0D) {
+                Label rateLabel = new Label();
+                rateLabel.setText("発動率");
+                rateLabel.getStyleClass().add("title");
+                this.getChildren().add(rateLabel);
+                this.getChildren().add(new FleetTabShipPopupRate(barrageRate, "対空噴進弾幕"));
+            }
         } else {
             for (int i = 0; i < this.chara.getSlot().size(); i++) {
                 if (this.chara.getSlot().get(i) > 0) {
@@ -189,6 +197,50 @@ public class FleetTabShipPopup extends VBox {
                 this.image.setImage(Items.itemImage(item));
                 this.name.setText(item.getName());
             }
+        }
+    }
+
+    /**
+     * 艦隊タブポップアップの発動率
+     *
+     */
+    private static class FleetTabShipPopupRate extends HBox {
+
+        @FXML
+        private Label kind;
+
+        @FXML
+        private Label percent;
+
+        /** 発動率 */
+        private double rate;
+
+        /** 種類 */
+        private String name;
+
+        /**
+         * 艦隊タブポップアップのコンストラクタ
+         *
+         * @param rate 発動率
+         * @param name 種類
+         */
+        public FleetTabShipPopupRate(double rate, String name) {
+            this.rate = rate;
+            this.name = name;
+            try {
+                FXMLLoader loader = InternalFXMLLoader.load("logbook/gui/fleet_tab_popup_rate.fxml");
+                loader.setRoot(this);
+                loader.setController(this);
+                loader.load();
+            } catch (IOException e) {
+                LoggerHolder.get().error("FXMLのロードに失敗しました", e);
+            }
+        }
+
+        @FXML
+        void initialize() {
+            this.kind.setText(this.name);
+            this.percent.setText(String.valueOf(this.rate) + "%");
         }
     }
 }

--- a/src/main/resources/logbook/gui/fleet_tab_popup_rate.css
+++ b/src/main/resources/logbook/gui/fleet_tab_popup_rate.css
@@ -1,0 +1,8 @@
+.popup-item {
+    -fx-alignment: CENTER;
+}
+.rate {
+    -fx-min-width: 4.5em;
+    -fx-padding: 0 0.5em 0 0;
+    -fx-alignment: CENTER_RIGHT;
+}

--- a/src/main/resources/logbook/gui/fleet_tab_popup_rate.fxml
+++ b/src/main/resources/logbook/gui/fleet_tab_popup_rate.fxml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.HBox?>
+
+
+<fx:root maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" styleClass="popup-item" stylesheets="@fleet_tab_popup_rate.css" type="HBox" xmlns="http://javafx.com/javafx/8.0.131" xmlns:fx="http://javafx.com/fxml/1">
+   <children>
+      <Label fx:id="percent" styleClass="rate" />
+      <Label fx:id="kind" />
+   </children>
+</fx:root>


### PR DESCRIPTION
12cm30連想噴進砲改二を装備した時に発動する対空噴進弾幕の発動率を艦隊ポップアップで表示します
![image](https://user-images.githubusercontent.com/13777426/51122302-e2a47f80-185c-11e9-8fb9-e689d370fa19.png)

加重対空値の式は[ここ](http://jbbs.shitaraba.net/bbs/read.cgi/netgame/13745/1439793270/205)を参照
[検証Wiki](http://ja.kancolle.wikia.com/wiki/%E8%88%AA%E7%A9%BA%E6%88%A6)の表現に倣って加重対空値の関数では丸めていません。

対空噴進弾幕の発動率の式は[ここ](http://ja.kancolle.wikia.com/wiki/%E3%82%B9%E3%83%AC%E3%83%83%E3%83%89:2471#5)を参照
[攻略Wiki](https://wikiwiki.jp/kancolle/%E8%88%AA%E7%A9%BA%E6%88%A6#AntiAircraft)では加重対空値を丸めたものとしているので対空噴進弾幕の発動率では加重対空値を、`int(加重対空値/2)*2`としています
