### PR TITLE
slot_exchange_indexの構造変更に対応

### DIFF
--- a/src/main/java/logbook/api/ApiReqKaisouSlotExchangeIndex.java
+++ b/src/main/java/logbook/api/ApiReqKaisouSlotExchangeIndex.java
@@ -25,10 +25,7 @@ public class ApiReqKaisouSlotExchangeIndex implements APIListenerSpi {
                     .getShipMap();
 
             Integer shipId = Integer.valueOf(req.getParameter("api_id"));
-            Ship ship = shipMap.get(shipId)
-                    .clone();
-            ship.setSlot(JsonHelper.toIntegerList(data.getJsonArray("api_slot")));
-            shipMap.put(shipId, ship);
+            shipMap.put(shipId, Ship.toShip(data.getJsonObject("api_ship_data")));
         }
     }
 


### PR DESCRIPTION
おそらく日進のスロット数を変更する仕様に伴って変更された `/kcapi/api_req_kaisou/slot_exchange_index` の構造に対応させました

Fixes #122