### PR TITLE
メイン画面のメニューをスマートとワイドの両スタイルで共通の部品にする

### DIFF
--- a/src/main/java/logbook/internal/gui/MainMenuController.java
+++ b/src/main/java/logbook/internal/gui/MainMenuController.java
@@ -1,0 +1,350 @@
+package logbook.internal.gui;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Stream;
+
+import javafx.collections.ObservableList;
+import javafx.event.ActionEvent;
+import javafx.fxml.FXML;
+import javafx.scene.Scene;
+import javafx.scene.control.Alert.AlertType;
+import javafx.scene.control.Menu;
+import javafx.scene.control.MenuItem;
+import javafx.scene.control.SeparatorMenuItem;
+import javafx.scene.paint.Color;
+import javafx.stage.StageStyle;
+import logbook.bean.AppCondition;
+import logbook.bean.AppConfig;
+import logbook.bean.BattleLog;
+import logbook.internal.BattleLogs;
+import logbook.internal.BattleLogs.SimpleBattleLog;
+import logbook.internal.CheckUpdate;
+import logbook.internal.LoggerHolder;
+import logbook.internal.log.BattleResultLogFormat;
+import logbook.internal.log.LogWriter;
+import logbook.plugin.gui.MainCalcMenu;
+import logbook.plugin.gui.MainCommandMenu;
+import logbook.plugin.gui.MainExtMenu;
+import logbook.plugin.gui.Plugin;
+
+/**
+ * UIコントローラー
+ *
+ */
+public class MainMenuController extends WindowController {
+
+    // メイン画面のコントローラ
+    private MainController parentController;
+
+    /** コマンドメニュー */
+    @FXML
+    private Menu command;
+
+    /** 計算機 */
+    @FXML
+    private Menu calc;
+
+    /** その他 */
+    @FXML
+    private Menu ext;
+
+    @FXML
+    void initialize() {
+        try {
+            // プラグインによるメニューの追加
+            this.addMenuItem(MainCommandMenu.class, this.command.getItems());
+            this.addMenuItem(MainCalcMenu.class, this.calc.getItems());
+            this.addMenuItem(MainExtMenu.class, this.ext.getItems());
+        } catch (Exception e) {
+            LoggerHolder.get().error("FXMLの初期化に失敗しました", e);
+        }
+    }
+
+    public void setParentController(MainController parentController) {
+        this.parentController = parentController;
+    }
+
+    /**
+     * キャプチャ
+     *
+     * @param e ActionEvent
+     */
+    @FXML
+    void capture(ActionEvent e) {
+        try {
+            InternalFXMLLoader.showWindow("logbook/gui/capture.fxml", this.parentController.getWindow(), "キャプチャ");
+        } catch (Exception ex) {
+            LoggerHolder.get().error("キャプチャの初期化に失敗しました", ex);
+        }
+    }
+
+    /**
+     * 現在の戦闘
+     *
+     * @param e ActionEvent
+     */
+    @FXML
+    void battleStatus(ActionEvent e) {
+        try {
+            BattleLog log = AppCondition.get()
+                    .getBattleResult();
+            if (log == null || log.getBattle() == null) {
+                Path dir = Paths.get(AppConfig.get().getReportPath());
+                Path path = dir.resolve(new BattleResultLogFormat().fileName());
+                if (Files.exists(path)) {
+                    try (Stream<String> lines = Files.lines(path, LogWriter.DEFAULT_CHARSET)) {
+                        SimpleBattleLog battleLog = lines.skip(1).reduce((first, second) -> second)
+                                .map(SimpleBattleLog::new)
+                                .orElse(null);
+                        if (battleLog != null) {
+                            log = BattleLogs.read(BattleLogDetail.toBattleLogDetail(battleLog).getDate());
+                        }
+                    } catch (Exception ex) {
+                        log = null;
+                    }
+                }
+            }
+            if (log != null && log.getBattle() != null) {
+                BattleLog sendlog = log;
+                InternalFXMLLoader.showWindow("logbook/gui/battle_detail.fxml", this.parentController.getWindow(),
+                        "現在の戦闘", c -> {
+                            ((BattleDetail) c).setInterval(() -> AppCondition.get().getBattleResult());
+                            ((BattleDetail) c).setData(sendlog);
+                        }, null);
+            } else {
+                Tools.Conrtols.alert(AlertType.INFORMATION, "現在の戦闘", "戦闘中ではありません", this.parentController.getWindow());
+            }
+        } catch (Exception ex) {
+            LoggerHolder.get().error("詳細の表示に失敗しました", ex);
+        }
+    }
+
+    /**
+     * 戦闘ログ
+     *
+     * @param e ActionEvent
+     */
+    @FXML
+    void battlelog(ActionEvent e) {
+        try {
+            InternalFXMLLoader.showWindow("logbook/gui/battlelog.fxml", this.parentController.getWindow(), "戦闘ログ");
+        } catch (Exception ex) {
+            LoggerHolder.get().error("戦闘ログの初期化に失敗しました", ex);
+        }
+    }
+
+    /**
+     * 遠征ログ
+     *
+     * @param e ActionEvent
+     */
+    @FXML
+    void missionlog(ActionEvent e) {
+        try {
+            InternalFXMLLoader.showWindow("logbook/gui/missionlog.fxml", this.parentController.getWindow(), "遠征ログ");
+        } catch (Exception ex) {
+            LoggerHolder.get().error("遠征ログの初期化に失敗しました", ex);
+        }
+    }
+
+    /**
+     * 開発ログ
+     *
+     * @param e ActionEvent
+     */
+    @FXML
+    void createitemlog(ActionEvent e) {
+        try {
+            InternalFXMLLoader.showWindow("logbook/gui/createitemlog.fxml", this.parentController.getWindow(), "開発ログ");
+        } catch (Exception ex) {
+            LoggerHolder.get().error("開発ログの初期化に失敗しました", ex);
+        }
+    }
+
+    /**
+     * 基地航空隊
+     *
+     * @param e ActionEvent
+     */
+    @FXML
+    void airBase(ActionEvent e) {
+        try {
+            InternalFXMLLoader.showWindow("logbook/gui/airbase.fxml", this.parentController.getWindow(), "基地航空隊");
+        } catch (Exception ex) {
+            LoggerHolder.get().error("基地航空隊の初期化に失敗しました", ex);
+        }
+    }
+
+    /**
+     * 所有装備
+     *
+     * @param e ActionEvent
+     */
+    @FXML
+    void items(ActionEvent e) {
+        this.parentController.items(e);
+    }
+
+    /**
+     * 所有艦娘
+     *
+     * @param e ActionEvent
+     */
+    @FXML
+    void ships(ActionEvent e) {
+        this.parentController.ships(e);
+    }
+
+    /**
+     * お風呂に入りたい艦娘
+     *
+     * @param e ActionEvent
+     */
+    @FXML
+    void ndock(ActionEvent e) {
+        try {
+            InternalFXMLLoader.showWindow("logbook/gui/require_ndock.fxml", this.parentController.getWindow(), "お風呂に入りたい艦娘");
+        } catch (Exception ex) {
+            LoggerHolder.get().error("お風呂に入りたい艦娘の初期化に失敗しました", ex);
+        }
+    }
+
+    /**
+     * 経験値計算機
+     *
+     * @param e ActionEvent
+     */
+    @FXML
+    void calcExp(ActionEvent e) {
+        try {
+            InternalFXMLLoader.showWindow("logbook/gui/calc_exp.fxml", this.parentController.getWindow(), "経験値計算機");
+        } catch (Exception ex) {
+            LoggerHolder.get().error("経験値計算機の初期化に失敗しました", ex);
+        }
+    }
+
+    /**
+     * 遠征条件確認
+     *
+     * @param e ActionEvent
+     */
+    @FXML
+    void missionCheck(ActionEvent e) {
+        try {
+            InternalFXMLLoader.showWindow("logbook/gui/missioncheck.fxml", this.parentController.getWindow(), "遠征条件確認");
+        } catch (Exception ex) {
+            LoggerHolder.get().error("遠征条件確認の初期化に失敗しました", ex);
+        }
+    }
+
+    /**
+     * 資材チャート
+     *
+     * @param e ActionEvent
+     */
+    @FXML
+    void resourceChart(ActionEvent e) {
+        try {
+            InternalFXMLLoader.showWindow("logbook/gui/resource_chart.fxml", this.parentController.getWindow(), "資材チャート");
+        } catch (Exception ex) {
+            LoggerHolder.get().error("資材チャートの初期化に失敗しました", ex);
+        }
+    }
+
+    /**
+     * 編成記録
+     *
+     * @param e ActionEvent
+     */
+    @FXML
+    void deck(ActionEvent e) {
+        try {
+            InternalFXMLLoader.showWindow("logbook/gui/deck.fxml", this.parentController.getWindow(), "編成記録");
+        } catch (Exception ex) {
+            LoggerHolder.get().error("編成記録の初期化に失敗しました", ex);
+        }
+    }
+
+    /**
+     * 自動プロキシ構成スクリプトファイル生成
+     *
+     * @param e ActionEvent
+     */
+    @FXML
+    void createPacFile(ActionEvent e) {
+        try {
+            InternalFXMLLoader.showWindow("logbook/gui/create_pac_file.fxml", this.parentController.getWindow(), "自動プロキシ構成スクリプトファイル生成");
+        } catch (Exception ex) {
+            LoggerHolder.get().error("自動プロキシ構成スクリプトファイル生成の初期化に失敗しました", ex);
+        }
+    }
+
+    /**
+     * 設定
+     *
+     * @param e ActionEvent
+     */
+    @FXML
+    void config(ActionEvent e) {
+        try {
+            InternalFXMLLoader.showWindow("logbook/gui/config.fxml", this.parentController.getWindow(), "設定");
+        } catch (Exception ex) {
+            LoggerHolder.get().error("設定の初期化に失敗しました", ex);
+        }
+    }
+
+    /**
+     * 更新を確認
+     *
+     * @param e ActionEvent
+     */
+    @FXML
+    void updateCheck(ActionEvent e) {
+        try {
+            CheckUpdate.run(this.parentController.getWindow());
+        } catch (Exception ex) {
+            LoggerHolder.get().error("更新情報の取得に失敗しました", ex);
+        }
+    }
+
+    /**
+     * バージョン情報
+     *
+     * @param e ActionEvent
+     */
+    @FXML
+    void version(ActionEvent e) {
+        try {
+            InternalFXMLLoader.showWindow("logbook/gui/version.fxml", this.parentController.getWindow(), "バージョン情報",
+                    root -> new Scene(root, Color.TRANSPARENT),
+                    null,
+                    stage -> {
+                        stage.initStyle(StageStyle.TRANSPARENT);
+                        stage.focusedProperty().addListener((ob, o, n) -> {
+                            if (!n) {
+                                stage.close();
+                            }
+                        });
+                    });
+        } catch (Exception ex) {
+            LoggerHolder.get().error("設定の初期化に失敗しました", ex);
+        }
+    }
+
+    /**
+     * プラグインのMenuItemを追加します
+     *
+     * @param serviceClass サービスプロバイダインターフェイス
+     * @param items MenuItemの追加先
+     */
+    private <S extends Plugin<MenuItem>> void addMenuItem(Class<S> serviceClass, ObservableList<MenuItem> items) {
+        List<MenuItem> addItem = Plugin.getContent(serviceClass);
+        if (!addItem.isEmpty()) {
+            items.add(new SeparatorMenuItem());
+            addItem.forEach(items::add);
+        }
+    }
+}

--- a/src/main/resources/logbook/gui/main.fxml
+++ b/src/main/resources/logbook/gui/main.fxml
@@ -2,82 +2,16 @@
 
 <?import java.net.URL?>
 <?import javafx.scene.control.Button?>
-<?import javafx.scene.control.Menu?>
-<?import javafx.scene.control.MenuBar?>
-<?import javafx.scene.control.MenuItem?>
 <?import javafx.scene.control.ScrollPane?>
-<?import javafx.scene.control.SeparatorMenuItem?>
 <?import javafx.scene.control.Tab?>
 <?import javafx.scene.control.TabPane?>
 <?import javafx.scene.control.TitledPane?>
-<?import javafx.scene.input.KeyCodeCombination?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
 
 <VBox prefHeight="455.0" prefWidth="300.0" styleClass="mainWindow" xmlns="http://javafx.com/javafx/8.0.162" xmlns:fx="http://javafx.com/fxml/1" fx:controller="logbook.internal.gui.MainController">
    <children>
-      <MenuBar>
-        <menus>
-          <Menu fx:id="command" mnemonicParsing="false" text="コマンド">
-            <items>
-              <MenuItem mnemonicParsing="false" onAction="#capture" text="キャプチャ" />
-              <SeparatorMenuItem mnemonicParsing="false" />
-              <MenuItem mnemonicParsing="false" onAction="#battleStatus" text="現在の戦闘" />
-              <MenuItem mnemonicParsing="false" onAction="#battlelog" text="戦闘ログ">
-                     <accelerator>
-                        <KeyCodeCombination alt="UP" code="A" control="DOWN" meta="UP" shift="UP" shortcut="UP" />
-                     </accelerator></MenuItem>
-              <MenuItem mnemonicParsing="false" onAction="#missionlog" text="遠征ログ">
-                     <accelerator>
-                        <KeyCodeCombination alt="UP" code="M" control="DOWN" meta="UP" shift="UP" shortcut="UP" />
-                     </accelerator></MenuItem>
-                  <MenuItem mnemonicParsing="false" onAction="#createitemlog" text="開発ログ" />
-              <SeparatorMenuItem mnemonicParsing="false" />
-                  <MenuItem mnemonicParsing="false" onAction="#airBase" text="基地航空隊">
-                     <accelerator>
-                        <KeyCodeCombination alt="UP" code="B" control="DOWN" meta="UP" shift="UP" shortcut="UP" />
-                     </accelerator>
-                  </MenuItem>
-              <MenuItem mnemonicParsing="false" onAction="#items" text="所有装備一覧">
-                     <accelerator>
-                        <KeyCodeCombination alt="UP" code="I" control="DOWN" meta="UP" shift="UP" shortcut="UP" />
-                     </accelerator></MenuItem>
-              <MenuItem mnemonicParsing="false" onAction="#ships" text="所有艦娘一覧">
-                     <accelerator>
-                        <KeyCodeCombination alt="UP" code="S" control="DOWN" meta="UP" shift="UP" shortcut="UP" />
-                     </accelerator></MenuItem>
-              <SeparatorMenuItem mnemonicParsing="false" />
-              <MenuItem mnemonicParsing="false" onAction="#ndock" text="お風呂に入りたい艦娘">
-                     <accelerator>
-                        <KeyCodeCombination alt="UP" code="N" control="DOWN" meta="UP" shift="UP" shortcut="UP" />
-                     </accelerator></MenuItem>
-            </items>
-          </Menu>
-          <Menu fx:id="calc" mnemonicParsing="false" text="計算機">
-               <items>
-                  <MenuItem mnemonicParsing="false" onAction="#calcExp" text="経験値計算機">
-                     <accelerator>
-                        <KeyCodeCombination alt="UP" code="C" control="DOWN" meta="UP" shift="UP" shortcut="UP" />
-                     </accelerator></MenuItem>
-                  <MenuItem mnemonicParsing="false" onAction="#missionCheck" text="遠征条件確認" />
-               </items>
-          </Menu>
-          <Menu fx:id="ext" mnemonicParsing="false" text="その他">
-            <items>
-                  <MenuItem mnemonicParsing="false" onAction="#resourceChart" text="資材チャート" />
-                  <MenuItem mnemonicParsing="false" onAction="#deck" text="編成記録" />
-                  <SeparatorMenuItem mnemonicParsing="false" />
-              <MenuItem mnemonicParsing="false" onAction="#createPacFile" text="自動プロキシ構成スクリプト" />
-                  <MenuItem mnemonicParsing="false" onAction="#config" text="設定">
-                     <accelerator>
-                        <KeyCodeCombination alt="UP" code="COMMA" control="UP" meta="UP" shift="UP" shortcut="DOWN" />
-                     </accelerator></MenuItem>
-                  <MenuItem mnemonicParsing="false" onAction="#updateCheck" text="更新を確認" />
-                  <MenuItem mnemonicParsing="false" onAction="#version" text="バージョン情報" />
-            </items>
-          </Menu>
-        </menus>
-      </MenuBar>
+      <fx:include fx:id="mainMenu" source="main_menu.fxml"/>
       <HBox styleClass="buttons">
          <children>
             <Button fx:id="item" maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#items" styleClass="itemButton" text="所有装備({0}/{1})" HBox.hgrow="ALWAYS" />

--- a/src/main/resources/logbook/gui/main_menu.fxml
+++ b/src/main/resources/logbook/gui/main_menu.fxml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.Menu?>
+<?import javafx.scene.control.MenuBar?>
+<?import javafx.scene.control.MenuItem?>
+<?import javafx.scene.control.SeparatorMenuItem?>
+<?import javafx.scene.input.KeyCodeCombination?>
+
+<MenuBar styleClass="mainMenu" xmlns="http://javafx.com/javafx/8.0.162" xmlns:fx="http://javafx.com/fxml/1" fx:controller="logbook.internal.gui.MainMenuController">
+   <menus>
+      <Menu fx:id="command" mnemonicParsing="false" text="コマンド">
+         <items>
+            <MenuItem mnemonicParsing="false" onAction="#capture" text="キャプチャ" />
+            <SeparatorMenuItem mnemonicParsing="false" />
+            <MenuItem mnemonicParsing="false" onAction="#battleStatus" text="現在の戦闘" />
+            <MenuItem mnemonicParsing="false" onAction="#battlelog" text="戦闘ログ">
+                   <accelerator>
+                      <KeyCodeCombination alt="UP" code="A" control="DOWN" meta="UP" shift="UP" shortcut="UP" />
+                   </accelerator></MenuItem>
+            <MenuItem mnemonicParsing="false" onAction="#missionlog" text="遠征ログ">
+                     <accelerator>
+                        <KeyCodeCombination alt="UP" code="M" control="DOWN" meta="UP" shift="UP" shortcut="UP" />
+                     </accelerator></MenuItem>
+            <MenuItem mnemonicParsing="false" onAction="#createitemlog" text="開発ログ" />
+            <SeparatorMenuItem mnemonicParsing="false" />
+            <MenuItem mnemonicParsing="false" onAction="#airBase" text="基地航空隊">
+                   <accelerator>
+                      <KeyCodeCombination alt="UP" code="B" control="DOWN" meta="UP" shift="UP" shortcut="UP" />
+                   </accelerator>
+            </MenuItem>
+            <MenuItem mnemonicParsing="false" onAction="#items" text="所有装備一覧">
+                   <accelerator>
+                      <KeyCodeCombination alt="UP" code="I" control="DOWN" meta="UP" shift="UP" shortcut="UP" />
+                   </accelerator></MenuItem>
+            <MenuItem mnemonicParsing="false" onAction="#ships" text="所有艦娘一覧">
+                   <accelerator>
+                      <KeyCodeCombination alt="UP" code="S" control="DOWN" meta="UP" shift="UP" shortcut="UP" />
+                   </accelerator></MenuItem>
+            <SeparatorMenuItem mnemonicParsing="false" />
+            <MenuItem mnemonicParsing="false" onAction="#ndock" text="お風呂に入りたい艦娘">
+                   <accelerator>
+                      <KeyCodeCombination alt="UP" code="N" control="DOWN" meta="UP" shift="UP" shortcut="UP" />
+                   </accelerator></MenuItem>
+         </items>
+      </Menu>
+
+      <Menu fx:id="calc" mnemonicParsing="false" text="計算機">
+         <items>
+            <MenuItem mnemonicParsing="false" onAction="#calcExp" text="経験値計算機">
+                   <accelerator>
+                      <KeyCodeCombination alt="UP" code="C" control="DOWN" meta="UP" shift="UP" shortcut="UP" />
+                   </accelerator></MenuItem>
+            <MenuItem mnemonicParsing="false" onAction="#missionCheck" text="遠征条件確認" />
+         </items>
+      </Menu>
+      <Menu fx:id="ext" mnemonicParsing="false" text="その他">
+         <items>
+            <MenuItem mnemonicParsing="false" onAction="#resourceChart" text="資材チャート" />
+            <MenuItem mnemonicParsing="false" onAction="#deck" text="編成記録" />
+            <SeparatorMenuItem mnemonicParsing="false" />
+            <MenuItem mnemonicParsing="false" onAction="#createPacFile" text="自動プロキシ構成スクリプト" />
+            <MenuItem mnemonicParsing="false" onAction="#config" text="設定">
+                   <accelerator>
+                      <KeyCodeCombination alt="UP" code="COMMA" control="UP" meta="UP" shift="UP" shortcut="DOWN" />
+                   </accelerator></MenuItem>
+            <MenuItem mnemonicParsing="false" onAction="#updateCheck" text="更新を確認" />
+            <MenuItem mnemonicParsing="false" onAction="#version" text="バージョン情報" />
+         </items>
+      </Menu>
+   </menus>
+</MenuBar>

--- a/src/main/resources/logbook/gui/main_wide.fxml
+++ b/src/main/resources/logbook/gui/main_wide.fxml
@@ -2,81 +2,16 @@
 
 <?import java.net.URL?>
 <?import javafx.scene.control.Button?>
-<?import javafx.scene.control.Menu?>
-<?import javafx.scene.control.MenuBar?>
-<?import javafx.scene.control.MenuItem?>
 <?import javafx.scene.control.ScrollPane?>
-<?import javafx.scene.control.SeparatorMenuItem?>
 <?import javafx.scene.control.SplitPane?>
 <?import javafx.scene.control.TabPane?>
 <?import javafx.scene.control.TitledPane?>
-<?import javafx.scene.input.KeyCodeCombination?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
 
 <VBox prefHeight="455.0" prefWidth="600.0" styleClass="mainWindow" xmlns="http://javafx.com/javafx/8.0.162" xmlns:fx="http://javafx.com/fxml/1" fx:controller="logbook.internal.gui.MainController">
    <children>
-      <MenuBar>
-        <menus>
-          <Menu fx:id="command" mnemonicParsing="false" text="コマンド">
-            <items>
-              <MenuItem mnemonicParsing="false" onAction="#capture" text="キャプチャ" />
-              <SeparatorMenuItem mnemonicParsing="false" />
-              <MenuItem mnemonicParsing="false" onAction="#battleStatus" text="現在の戦闘" />
-              <MenuItem mnemonicParsing="false" onAction="#battlelog" text="戦闘ログ">
-                     <accelerator>
-                        <KeyCodeCombination alt="UP" code="A" control="DOWN" meta="UP" shift="UP" shortcut="UP" />
-                     </accelerator></MenuItem>
-              <MenuItem mnemonicParsing="false" onAction="#missionlog" text="遠征ログ">
-                     <accelerator>
-                        <KeyCodeCombination alt="UP" code="M" control="DOWN" meta="UP" shift="UP" shortcut="UP" />
-                     </accelerator></MenuItem>
-                  <MenuItem mnemonicParsing="false" onAction="#createitemlog" text="開発ログ" />
-              <SeparatorMenuItem mnemonicParsing="false" />
-                  <MenuItem mnemonicParsing="false" onAction="#airBase" text="基地航空隊">
-                     <accelerator>
-                        <KeyCodeCombination alt="UP" code="B" control="DOWN" meta="UP" shift="UP" shortcut="UP" />
-                     </accelerator>
-                  </MenuItem>
-              <MenuItem mnemonicParsing="false" onAction="#items" text="所有装備一覧">
-                     <accelerator>
-                        <KeyCodeCombination alt="UP" code="I" control="DOWN" meta="UP" shift="UP" shortcut="UP" />
-                     </accelerator></MenuItem>
-              <MenuItem mnemonicParsing="false" onAction="#ships" text="所有艦娘一覧">
-                     <accelerator>
-                        <KeyCodeCombination alt="UP" code="S" control="DOWN" meta="UP" shift="UP" shortcut="UP" />
-                     </accelerator></MenuItem>
-              <SeparatorMenuItem mnemonicParsing="false" />
-              <MenuItem mnemonicParsing="false" onAction="#ndock" text="お風呂に入りたい艦娘">
-                     <accelerator>
-                        <KeyCodeCombination alt="UP" code="N" control="DOWN" meta="UP" shift="UP" shortcut="UP" />
-                     </accelerator></MenuItem>
-            </items>
-          </Menu>
-          <Menu fx:id="calc" mnemonicParsing="false" text="計算機">
-               <items>
-                  <MenuItem mnemonicParsing="false" onAction="#calcExp" text="経験値計算機">
-                     <accelerator>
-                        <KeyCodeCombination alt="UP" code="C" control="DOWN" meta="UP" shift="UP" shortcut="UP" />
-                     </accelerator></MenuItem>
-                  <MenuItem mnemonicParsing="false" onAction="#missionCheck" text="遠征条件確認" />
-               </items>
-          </Menu>
-          <Menu fx:id="ext" mnemonicParsing="false" text="その他">
-            <items>
-                  <MenuItem mnemonicParsing="false" onAction="#resourceChart" text="資材チャート" />
-                  <MenuItem mnemonicParsing="false" onAction="#deck" text="編成記録" />
-                  <SeparatorMenuItem mnemonicParsing="false" />
-              <MenuItem mnemonicParsing="false" onAction="#createPacFile" text="自動プロキシ構成スクリプト" />
-                  <MenuItem mnemonicParsing="false" onAction="#config" text="設定">
-                     <accelerator>
-                        <KeyCodeCombination alt="UP" code="COMMA" control="UP" meta="UP" shift="UP" shortcut="DOWN" />
-                     </accelerator></MenuItem>
-                  <MenuItem mnemonicParsing="false" onAction="#version" text="バージョン情報" />
-            </items>
-          </Menu>
-        </menus>
-      </MenuBar>
+      <fx:include fx:id="mainMenu" source="main_menu.fxml"/>
       <SplitPane dividerPositions="0.5" VBox.vgrow="ALWAYS">
          <items>
             <VBox>


### PR DESCRIPTION
#82 で追加した任意更新のメニューがメイン画面のスタイルをワイドにしていると存在しなかったので修正

main.fxmlとmain_wide.fxmlで重複しているのでメニューを別のファイルへ切り出して読み込む形に変更