### PR TITLE
ワイド時のScrollPaneの高さを修正

### DIFF
--- a/src/main/resources/logbook/gui/main_wide.fxml
+++ b/src/main/resources/logbook/gui/main_wide.fxml
@@ -11,6 +11,7 @@
 <?import javafx.scene.control.TabPane?>
 <?import javafx.scene.control.TitledPane?>
 <?import javafx.scene.input.KeyCodeCombination?>
+<?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
 
@@ -79,14 +80,16 @@
       </MenuBar>
       <SplitPane dividerPositions="0.5" VBox.vgrow="ALWAYS">
          <items>
-            <VBox>
-               <children>
+           <BorderPane>
+               <top>
                   <HBox styleClass="buttons">
                      <children>
                         <Button fx:id="item" maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#items" styleClass="itemButton" text="所有装備({0}/{1})" HBox.hgrow="ALWAYS" />
                         <Button fx:id="ship" maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#ships" styleClass="shipButton" text="所有艦娘({0}/{1})" HBox.hgrow="ALWAYS" />
                      </children>
                   </HBox>
+               </top>
+               <center>
                   <ScrollPane fitToWidth="true">
                      <content>
                         <VBox fx:id="infobox">
@@ -115,8 +118,8 @@
                         </VBox>
                      </content>
                   </ScrollPane>
-               </children>
-            </VBox>
+               </center>
+            </BorderPane>
             <TabPane fx:id="fleetTab" />
          </items>
       </SplitPane>


### PR DESCRIPTION
メイン画面をワイドにしている際、任務詳細を表示した時のScrollPaneが画面一杯まで広がらないので修正
