### PR TITLE
入渠ドックが更新された際にお風呂に入りたい艦娘に表示されないようにする

### DIFF
--- a/src/main/java/logbook/api/ApiGetMemberNdock.java
+++ b/src/main/java/logbook/api/ApiGetMemberNdock.java
@@ -46,7 +46,10 @@ public class ApiGetMemberNdock implements APIListenerSpi {
                     .map(ShipCollection.get().getShipMap()::get)
                     .filter(Objects::nonNull)
                     .filter(ship -> ship.getNowhp() < ship.getMaxhp())
-                    .forEach(ship -> ship.setNowhp(ship.getMaxhp()));
+                    .forEach(ship -> {
+                        ship.setNowhp(ship.getMaxhp());
+                        ship.setNdockTime(0);
+                    });
         }
     }
 


### PR DESCRIPTION
#93 の変更では入渠時間が更新されていないため、修復が完了した艦娘がお風呂に入りたい艦娘に表示されたままになるので修正