### PR TITLE
遠征条件の修正

### DIFF
--- a/src/main/resources/logbook/mission/7/43.json
+++ b/src/main/resources/logbook/mission/7/43.json
@@ -18,7 +18,7 @@
                                     "operator": "AND",
                                     "conditions": [
                                         {"type": "艦娘", "ship_type" :["駆逐艦"]},
-                                        {"type": "艦娘"},
+                                        {"type": "艦娘", "ship_type" :["駆逐艦"]},
                                         {"type": "艦娘"},
                                         {"type": "艦娘"},
                                         {"type": "艦娘"}


### PR DESCRIPTION
ミ船団護衛(二号船団)の条件のうち、`駆逐or海防艦2`の条件にあってなかった部分を修正