### PR TITLE
艦隊タブに火力・対空・対潜・索敵の合計を表示

### DIFF
--- a/src/main/java/logbook/internal/gui/FleetTabPane.java
+++ b/src/main/java/logbook/internal/gui/FleetTabPane.java
@@ -118,6 +118,38 @@ public class FleetTabPane extends ScrollPane {
     @FXML
     private Label cond;
 
+    /** 火力合計アイコン */
+    @FXML
+    private ImageView karyokusumImg;
+
+    /** 火力合計 */
+    @FXML
+    private Label karyokusum;
+
+    /** 対空合計アイコン */
+    @FXML
+    private ImageView taikusumImg;
+
+    /** 対空合計 */
+    @FXML
+    private Label taikusum;
+
+    /** 対潜合計アイコン */
+    @FXML
+    private ImageView taissumImg;
+
+    /** 対潜合計 */
+    @FXML
+    private Label taissum;
+
+    /** 索敵合計アイコン */
+    @FXML
+    private ImageView sakutekisumImg;
+
+    /** 索敵合計 */
+    @FXML
+    private Label sakutekisum;
+
     /** 注釈 */
     @FXML
     private VBox remark;
@@ -265,6 +297,14 @@ public class FleetTabPane extends ScrollPane {
         this.setDecision33();
         // 艦娘レベル計
         this.lvsum.setText(Integer.toString(withoutEscape.stream().mapToInt(Ship::getLv).sum()));
+        // 火力合計
+        this.karyokusum.setText(Integer.toString(withoutEscape.stream().mapToInt(ship -> ship.getKaryoku().get(0)).sum()));
+        // 対空合計
+        this.taikusum.setText(Integer.toString(withoutEscape.stream().mapToInt(ship -> ship.getTaiku().get(0)).sum()));
+        // 対潜合計
+        this.taissum.setText(Integer.toString(withoutEscape.stream().mapToInt(ship -> ship.getTaisen().get(0)).sum()));
+        // 索敵合計
+        this.sakutekisum.setText(Integer.toString(withoutEscape.stream().mapToInt(ship -> ship.getSakuteki().get(0)).sum()));
 
         ObservableList<Node> childs = this.ships.getChildren();
         childs.clear();
@@ -347,6 +387,10 @@ public class FleetTabPane extends ScrollPane {
         this.touchPlaneStartProbabilityImg.setImage(Items.itemImageByType(10));
         this.decision33Img.setImage(Items.itemImageByType(9));
         this.lvsumImg.setImage(Items.itemImageByType(28));
+        this.karyokusumImg.setImage(Items.itemImageByType(3));
+        this.taikusumImg.setImage(Items.itemImageByType(15));
+        this.taissumImg.setImage(Items.itemImageByType(17));
+        this.sakutekisumImg.setImage(Items.itemImageByType(11));
     }
 
     /**

--- a/src/main/resources/logbook/gui/fleet_tab.fxml
+++ b/src/main/resources/logbook/gui/fleet_tab.fxml
@@ -79,6 +79,34 @@
                                  </children>
                               </HBox>
                               <Label fx:id="cond" styleClass="value" GridPane.columnIndex="3" GridPane.rowIndex="2" />
+                              <HBox alignment="CENTER_LEFT" GridPane.rowIndex="3">
+                                 <children>
+                                    <ImageView fx:id="karyokusumImg" fitHeight="24.0" fitWidth="24.0" pickOnBounds="true" preserveRatio="true" />
+                                    <Label text="火力合計:" />
+                                 </children>
+                              </HBox>
+                              <Label fx:id="karyokusum" styleClass="value" GridPane.columnIndex="1" GridPane.rowIndex="3" />
+                              <HBox alignment="CENTER_LEFT" GridPane.columnIndex="2" GridPane.rowIndex="3">
+                                 <children>
+                                    <ImageView fx:id="taikusumImg" fitHeight="24.0" fitWidth="24.0" pickOnBounds="true" preserveRatio="true" />
+                                    <Label text="対空合計:" />
+                                 </children>
+                              </HBox>
+                              <Label fx:id="taikusum" styleClass="value" GridPane.columnIndex="3" GridPane.rowIndex="3" />
+                              <HBox alignment="CENTER_LEFT" GridPane.rowIndex="4">
+                                 <children>
+                                    <ImageView fx:id="taissumImg" fitHeight="24.0" fitWidth="24.0" pickOnBounds="true" preserveRatio="true" />
+                                    <Label text="対潜合計:" />
+                                 </children>
+                              </HBox>
+                              <Label fx:id="taissum" styleClass="value" GridPane.columnIndex="1" GridPane.rowIndex="4" />
+                              <HBox alignment="CENTER_LEFT" GridPane.columnIndex="2" GridPane.rowIndex="4">
+                                 <children>
+                                    <ImageView fx:id="sakutekisumImg" fitHeight="24.0" fitWidth="24.0" pickOnBounds="true" preserveRatio="true" />
+                                    <Label text="索敵合計:" />
+                                 </children>
+                              </HBox>
+                              <Label fx:id="sakutekisum" styleClass="value" GridPane.columnIndex="3" GridPane.rowIndex="4" />
                            </children>
                         </GridPane>
                      </children>


### PR DESCRIPTION
最近実装された遠征には、遠征艦隊の火力などの合計がある一定値以上でないと成功しない場合があるので、艦隊タブで合計が見れると便利かと思い実装してみました。ご検討のほどよろしくお願いいたします。

↓こんな感じになります。
<img width="316" alt="スクリーンショット 2020-05-03 15 21 40" src="https://user-images.githubusercontent.com/3181895/80907400-dabe6680-8d51-11ea-8991-035703fa1db7.png">
