### PR TITLE
重複した request を追加しない

### DIFF
--- a/src/main/java/logbook/internal/proxy/CaptureHolder.java
+++ b/src/main/java/logbook/internal/proxy/CaptureHolder.java
@@ -2,6 +2,7 @@ package logbook.internal.proxy;
 
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class CaptureHolder {
@@ -11,6 +12,10 @@ public class CaptureHolder {
     private List<byte[]> res = new ArrayList<>();
 
     public void putRequest(byte[] data) {
+        if (this.req.size() > 0 && Arrays.equals(this.req.get(this.req.size()-1), data)) {
+            // if the data is the same as the last one in this.req array, no need to add this to req as it is duplicated
+            return;
+        }
         this.req.add(data);
     }
 


### PR DESCRIPTION
以前 Issue #158 として上げた問題の対応コードです。今でも `putRequest()` が複数回呼ばれる理由はわかっていませんが、以下のような修正を施した状態で３ヶ月程度問題なく動作したことを確認しています。ご検討のほどよろしくお願いいたします。