### PR TITLE
新規実装遠征への対応と遠征条件の一部追加

### DIFF
--- a/src/main/java/logbook/internal/Missions.java
+++ b/src/main/java/logbook/internal/Missions.java
@@ -52,7 +52,9 @@ public class Missions {
 
         InputStream is = PluginServices
                 .getResourceAsStream("logbook/mission/" + mission.getMapareaId() + "/" + mission.getDispNo() + ".json");
-
+        if (is == null) {
+            return Optional.empty();
+        }
         MissionCondition condition;
         try {
             ObjectMapper mapper = new ObjectMapper();

--- a/src/main/java/logbook/internal/gui/MissionCheck.java
+++ b/src/main/java/logbook/internal/gui/MissionCheck.java
@@ -153,6 +153,7 @@ public class MissionCheck extends WindowController {
                 item = this.buildLeaf(cond);
             } else if (mission.getSampleFleet() != null) {
                 item = new TreeItem<>();
+                setIcon(item, null);
             } else {
                 return null;
             }

--- a/src/main/resources/logbook/mission/1/A5.json
+++ b/src/main/resources/logbook/mission/1/A5.json
@@ -1,0 +1,61 @@
+/*小笠原沖哨戒線*/
+{
+    "operator": "AND",
+    "conditions": [
+        {"type": "艦隊", "count_type": "火力", "value": 280},
+        {"type": "艦隊", "count_type": "対空", "value": 220},
+        {"type": "艦隊", "count_type": "対潜", "value": 240},
+        {"type": "艦隊", "count_type": "索敵", "value": 150},
+        {
+            "operator": "AND",
+            "conditions": [
+                {"type": "艦娘", "level": 45, "order": 1}
+            ]
+        },
+        {
+            "operator": "OR",
+            "conditions": [
+                {
+                    "operator": "AND",
+                    "conditions": [
+                        {"type": "艦娘", "ship_type" :["軽巡洋艦"]},
+                        {"type": "艦娘", "ship_type" :["駆逐艦"]},
+                        {"type": "艦娘", "ship_type" :["駆逐艦"]},
+                        {"type": "艦娘", "ship_type" :["駆逐艦"]},
+                        {"type": "艦娘"}
+                    ]
+                },
+                {
+                    "operator": "AND",
+                    "conditions": [
+                        {"type": "艦娘", "ship_type" :["駆逐艦"]},
+                        {"type": "艦娘", "ship_type" :["海防艦"]},
+                        {"type": "艦娘", "ship_type" :["海防艦"]},
+                        {"type": "艦娘", "ship_type" :["海防艦"]},
+                        {"type": "艦娘"}
+                    ]
+                },
+                {
+                    "operator": "AND",
+                    "conditions": [
+                        {"type": "艦娘", "ship_type" :["護衛空母"]},
+                        {"type": "艦娘", "ship_type" :["駆逐艦"]},
+                        {"type": "艦娘", "ship_type" :["駆逐艦"]},
+                        {"type": "艦娘"},
+                        {"type": "艦娘"}
+                    ]
+                },
+                {
+                    "operator": "AND",
+                    "conditions": [
+                        {"type": "艦娘", "ship_type" :["軽巡洋艦", "練習巡洋艦"]},
+                        {"type": "艦娘", "ship_type" :["海防艦"]},
+                        {"type": "艦娘", "ship_type" :["海防艦"]},
+                        {"type": "艦娘"},
+                        {"type": "艦娘"}
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/logbook/mission/1/A6.json
+++ b/src/main/resources/logbook/mission/1/A6.json
@@ -1,0 +1,65 @@
+/*小笠原沖戦闘哨戒*/
+{
+    "operator": "AND",
+    "conditions": [
+        {"type": "艦隊", "count_type": "火力", "value": 330},
+        {"type": "艦隊", "count_type": "対空", "value": 300},
+        {"type": "艦隊", "count_type": "対潜", "value": 270},
+        {"type": "艦隊", "count_type": "索敵", "value": 180},
+        {
+            "operator": "AND",
+            "conditions": [
+                {"type": "艦娘", "level": 55, "order": 1}
+            ]
+        },
+        {
+            "operator": "OR",
+            "conditions": [
+                {
+                    "operator": "AND",
+                    "conditions": [
+                        {"type": "艦娘", "ship_type" :["軽巡洋艦"]},
+                        {"type": "艦娘", "ship_type" :["駆逐艦"]},
+                        {"type": "艦娘", "ship_type" :["駆逐艦"]},
+                        {"type": "艦娘", "ship_type" :["駆逐艦"]},
+                        {"type": "艦娘"},
+                        {"type": "艦娘"}
+                    ]
+                },
+                {
+                    "operator": "AND",
+                    "conditions": [
+                        {"type": "艦娘", "ship_type" :["駆逐艦"]},
+                        {"type": "艦娘", "ship_type" :["海防艦"]},
+                        {"type": "艦娘", "ship_type" :["海防艦"]},
+                        {"type": "艦娘", "ship_type" :["海防艦"]},
+                        {"type": "艦娘"},
+                        {"type": "艦娘"}
+                    ]
+                },
+                {
+                    "operator": "AND",
+                    "conditions": [
+                        {"type": "艦娘", "ship_type" :["護衛空母"]},
+                        {"type": "艦娘", "ship_type" :["海防艦", "駆逐艦"]},
+                        {"type": "艦娘", "ship_type" :["海防艦", "駆逐艦"]},
+                        {"type": "艦娘"},
+                        {"type": "艦娘"},
+                        {"type": "艦娘"}
+                    ]
+                },
+                {
+                    "operator": "AND",
+                    "conditions": [
+                        {"type": "艦娘", "ship_type" :["軽巡洋艦", "練習巡洋艦"]},
+                        {"type": "艦娘", "ship_type" :["海防艦"]},
+                        {"type": "艦娘", "ship_type" :["海防艦"]},
+                        {"type": "艦娘"},
+                        {"type": "艦娘"},
+                        {"type": "艦娘"}
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/logbook/mission/2/B5.json
+++ b/src/main/resources/logbook/mission/2/B5.json
@@ -1,0 +1,27 @@
+/*南西諸島捜索撃滅戦*/
+{
+    "operator": "AND",
+    "conditions": [
+        {"type": "艦隊", "count_type": "火力", "value": 510},
+        {"type": "艦隊", "count_type": "対空", "value": 400},
+        {"type": "艦隊", "count_type": "対潜", "value": 285},
+        {"type": "艦隊", "count_type": "索敵", "value": 385},
+        {
+            "operator": "AND",
+            "conditions": [
+                {"type": "艦娘", "level": 60, "order": 1}
+            ]
+        },
+        {
+            "operator": "AND",
+            "conditions": [
+                {"type": "艦娘", "ship_type" :["水上機母艦"]},
+                {"type": "艦娘", "ship_type" :["軽巡洋艦"]},
+                {"type": "艦娘", "ship_type" :["駆逐艦"]},
+                {"type": "艦娘", "ship_type" :["駆逐艦"]},
+                {"type": "艦娘"},
+                {"type": "艦娘"}
+            ]
+        }
+    ]
+}

--- a/src/main/resources/logbook/mission/4/D1.json
+++ b/src/main/resources/logbook/mission/4/D1.json
@@ -1,0 +1,25 @@
+/*西方海域偵察作戦*/
+{
+    "operator": "AND",
+    "conditions": [
+        {"type": "艦隊", "count_type": "対空", "value": 240},
+        {"type": "艦隊", "count_type": "対潜", "value": 240},
+        {"type": "艦隊", "count_type": "索敵", "value": 300},
+        {
+            "operator": "AND",
+            "conditions": [
+                {"type": "艦娘", "level": 50, "order": 1}
+            ]
+        },
+        {
+            "operator": "AND",
+            "conditions": [
+                {"type": "艦娘", "ship_type" :["水上機母艦"], "order": 1},
+                {"type": "艦娘", "ship_type" :["駆逐艦"]},
+                {"type": "艦娘", "ship_type" :["駆逐艦"]},
+                {"type": "艦娘", "ship_type" :["駆逐艦"]},
+                {"type": "艦娘"}
+            ]
+        }
+    ]
+}

--- a/src/main/resources/logbook/mission/4/D2.json
+++ b/src/main/resources/logbook/mission/4/D2.json
@@ -1,0 +1,25 @@
+/*西方潜水艦作戦*/
+{
+    "operator": "AND",
+    "conditions": [
+        {"type": "艦隊", "count_type": "火力", "value": 60},
+        {"type": "艦隊", "count_type": "対空", "value": 80},
+        {"type": "艦隊", "count_type": "対潜", "value": 50},
+        {
+            "operator": "AND",
+            "conditions": [
+                {"type": "艦娘", "level": 55, "order": 1}
+            ]
+        },
+        {
+            "operator": "AND",
+            "conditions": [
+                {"type": "艦娘", "ship_type" :["潜水母艦"], "order": 1},
+                {"type": "艦娘", "ship_type" :["潜水艦", "潜水空母"]},
+                {"type": "艦娘", "ship_type" :["潜水艦", "潜水空母"]},
+                {"type": "艦娘", "ship_type" :["潜水艦", "潜水空母"]},
+                {"type": "艦娘"}
+            ]
+        }
+    ]
+}

--- a/src/main/resources/logbook/mission/5/E1.json
+++ b/src/main/resources/logbook/mission/5/E1.json
@@ -1,0 +1,27 @@
+/*ラバウル方面艦隊進出*/
+{
+    "operator": "AND",
+    "conditions": [
+        {"type": "艦隊", "count_type": "火力", "value": 450},
+        {"type": "艦隊", "count_type": "対空", "value": 350},
+        {"type": "艦隊", "count_type": "対潜", "value": 330},
+        {"type": "艦隊", "count_type": "索敵", "value": 250},
+        {
+            "operator": "AND",
+            "conditions": [
+                {"type": "艦娘", "level": 55, "order": 1}
+            ]
+        },
+        {
+            "operator": "AND",
+            "conditions": [
+                {"type": "艦娘", "ship_type" :["重巡洋艦"], "order": 1},
+                {"type": "艦娘", "ship_type" :["軽巡洋艦"]},
+                {"type": "艦娘", "ship_type" :["駆逐艦"]},
+                {"type": "艦娘", "ship_type" :["駆逐艦"]},
+                {"type": "艦娘", "ship_type" :["駆逐艦"]},
+                {"type": "艦娘"}
+            ]
+        }
+    ]
+}

--- a/src/main/resources/logbook/mission/7/45.json
+++ b/src/main/resources/logbook/mission/7/45.json
@@ -1,0 +1,40 @@
+/*ボーキサイト船団護衛*/
+{
+    "operator": "AND",
+    "conditions": [
+        {"type": "艦隊", "count_type": "対空", "value": 240},
+        {"type": "艦隊", "count_type": "対潜", "value": 300},
+        {"type": "艦隊", "count_type": "索敵", "value": 180},
+        {
+            "operator": "AND",
+            "conditions": [
+                {"type": "艦娘", "level": 50, "order": 1}
+            ]
+        },
+        {
+            "operator": "OR",
+            "conditions": [
+                {
+                    "operator": "AND",
+                    "conditions": [
+                        {"type": "艦娘", "ship_type" :["護衛空母"], "order": 1},
+                        {"type": "艦娘", "ship_type" :["駆逐艦", "海防艦"]},
+                        {"type": "艦娘", "ship_type" :["駆逐艦", "海防艦"]},
+                        {"type": "艦娘", "ship_type" :["駆逐艦", "海防艦"]},
+                        {"type": "艦娘", "ship_type" :["駆逐艦", "海防艦"]}
+                    ]
+                },
+                {
+                    "operator": "AND",
+                    "conditions": [
+                        {"type": "艦娘", "ship_type" :["軽空母"], "order": 1},
+                        {"type": "艦娘", "ship_type" :["駆逐艦", "海防艦"]},
+                        {"type": "艦娘", "ship_type" :["駆逐艦", "海防艦"]},
+                        {"type": "艦娘", "ship_type" :["駆逐艦", "海防艦"]},
+                        {"type": "艦娘", "ship_type" :["駆逐艦", "海防艦"]}
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
お世話になっております。

遠征が新規に実装され logbook-kai でまだ遠征条件が定義されていない場合に遠征条件確認のダイアログを開くと、[Missions.java:62](https://github.com/sanaehirotaka/logbook-kai/blob/master/src/main/java/logbook/internal/Missions.java#L62)でNPEが発生するようです。今後も新しい遠征が追加されると考えられるので、NPEの対応と未対応の遠征の場合には「？」のアイコンを表示するようにしてみました。

また、3月ごろに追加された遠征について遠征条件の定義を作成してみました。5月追加分（A5/A6）はまだ条件が不明なところも多いようなので作成していません。

ご検討のほどよろしくお願いします。