### PR TITLE
判定式(33)周りの修正

### DIFF
--- a/src/main/java/logbook/internal/Ships.java
+++ b/src/main/java/logbook/internal/Ships.java
@@ -707,8 +707,7 @@ public class Ships {
                 .getSlotitemMap();
         // 艦娘から装備を取り出すFunction
         Function<Ship, Stream<SlotItem>> toSlotItem = ship -> {
-            return ship.getSlot()
-                    .stream()
+            return Stream.concat(ship.getSlot().stream(), Stream.of(ship.getSlotEx()))
                     .map(itemMap::get)
                     .filter(Objects::nonNull);
         };

--- a/src/main/java/logbook/internal/Ships.java
+++ b/src/main/java/logbook/internal/Ships.java
@@ -72,6 +72,8 @@ public class Ships {
         // 索敵係数
         // 小口径主砲：0.6
         VIEW_COEFFICIENT.put(SlotItemType.小口径主砲, 0.6D);
+        // 中口径主砲 : 0.6
+        VIEW_COEFFICIENT.put(SlotItemType.中口径主砲, 0.6D);
         // 艦上戦闘機：0.6
         VIEW_COEFFICIENT.put(SlotItemType.艦上戦闘機, 0.6D);
         // 艦上爆撃機：0.6
@@ -88,10 +90,18 @@ public class Ships {
         VIEW_COEFFICIENT.put(SlotItemType.小型電探, 0.6D);
         // 大型電探：0.6
         VIEW_COEFFICIENT.put(SlotItemType.大型電探, 0.6D);
+        // ソナー：0.6
+        VIEW_COEFFICIENT.put(SlotItemType.ソナー,  0.6D);
+        // 特殊潜航艇：0.6
+        VIEW_COEFFICIENT.put(SlotItemType.特殊潜航艇, 0.6D);
+        // オートジャイロ：0.6
+        VIEW_COEFFICIENT.put(SlotItemType.オートジャイロ, 0.6D);
         // 対潜哨戒機：0.6
         VIEW_COEFFICIENT.put(SlotItemType.対潜哨戒機, 0.6D);
         // 探照灯：0.6
         VIEW_COEFFICIENT.put(SlotItemType.探照灯, 0.6D);
+        // 潜水艦魚雷：0.6
+        VIEW_COEFFICIENT.put(SlotItemType.潜水艦魚雷, 0.6D);
         // 司令部施設：0.6
         VIEW_COEFFICIENT.put(SlotItemType.司令部施設, 0.6D);
         // 航空要員(熟練艦載機整備員)：0.6


### PR DESCRIPTION
#### 修正内容
- おそらく開発当時には索敵値がある装備がなかったため判定式の索敵係数に定義されていなかった slotitemtype を追加
- 拡張スロットの装備が索敵値の計算に反映されていなかったのを追加

Fixes #166
Fixes #167 