### PR TITLE
複数のマップで同一の海域名を持つ場合に対応 #173

### DIFF
--- a/src/main/java/logbook/internal/log/BattleResultLogFormat.java
+++ b/src/main/java/logbook/internal/log/BattleResultLogFormat.java
@@ -106,7 +106,13 @@ public class BattleResultLogFormat extends LogFormatBase<BattleLog> {
 
         Format format = new Format();
         format.日付 = log.getTime();
-        format.海域 = result.getQuestName();
+        format.海域 = new StringBuilder(32)
+                .append(log.getNext().get(0).getMapareaId())
+                .append("-")
+                .append(log.getNext().get(0).getMapinfoNo())
+                .append(" ")
+                .append(result.getQuestName())
+                .toString();
         format.マス = String.valueOf(log.getNext().get(log.getNext().size() - 1).getNo());
         format.ボス = bossText.apply(log);
         format.ランク = result.getWinRank();


### PR DESCRIPTION
#### 問題解析
海域・ドロップ報告書の CSV には海域名しか入っておらず略称（1-1等）が入っていないため、戦闘ログで表示するときに海域名の文字列から逆引きしているが、2020梅雨イベのE2(48-2)は海域名が南西諸島沖という1-2と全く同じ海域名を使用しているので、E2に出撃した記録が1-2として扱われている。

#### 修正内容
CSVのフォーマット変更（カラム追加）は困難なので、海域名のカラムに海域名だけではなく略称を頭につけるように変更。（例：南西諸島沖 -> 1-2 南西諸島沖）また、戦闘ログビューにて読み込む際には正規表現で `[0-9]+-[0-9]+` のパターンであるかをチェックし、そうであれば先頭の部分を略称として使用し、そうでなければ従来通りの処理を行うように変更。

Fixes #173 

#### 免責事項
既にE2に出撃済みの場合はそのデータに関しては「南西諸島沖」となっており1-2なのかE2なのかは判別不可能なので、20.6.1以前で記録されたE2の出撃データは正しく取れない。

※修正はこれで大丈夫だとは思いますが、私がまだE2にたどり着いておらず未確認なのと、既存のデータを壊したくないのでもう少しテストしてからマージします。