### PR TITLE
cond 値自然回復検出ロジックを修正

### DIFF
--- a/src/main/java/logbook/api/ApiGetMemberShipDeck.java
+++ b/src/main/java/logbook/api/ApiGetMemberShipDeck.java
@@ -1,14 +1,10 @@
 package logbook.api;
 
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.util.Map;
-import java.util.function.Predicate;
 
 import javax.json.JsonArray;
 import javax.json.JsonObject;
 
-import logbook.bean.AppCondition;
 import logbook.bean.DeckPort;
 import logbook.bean.DeckPortCollection;
 import logbook.bean.Ship;
@@ -40,28 +36,34 @@ public class ApiGetMemberShipDeck implements APIListenerSpi {
      */
     private void apiShipData(JsonArray array) {
         // 差し替え前
-        Map<Integer, Ship> before = ShipCollection.get()
-                .getShipMap();
+//        Map<Integer, Ship> before = ShipCollection.get()
+//                .getShipMap();
 
         // 差し替え
         Map<Integer, Ship> map = ShipCollection.get()
                 .getShipMap();
         map.putAll(JsonHelper.toMap(array, Ship::getId, Ship::toShip));
-
-        // cond値が更新されたかを検出
-        Predicate<Ship> update = beforeShip -> {
-            Ship afterShip = map.get(beforeShip.getId());
-            if (afterShip != null) {
-                return !beforeShip.getCond().equals(afterShip.getCond());
-            }
-            return false;
-        };
-        if (before.values().stream()
-                .filter(ship -> ship.getCond() <= 49)
-                .anyMatch(update)) {
-            ZonedDateTime time = ZonedDateTime.now(ZoneId.systemDefault());
-            AppCondition.get().setCondUpdateTime(time.toEpochSecond());
-        }
+        
+        // 以下のコードは実際動いてなかった（setCondUpdateTime() にたどり着くことがなかった）。
+        // 理由は上で before に差し替え前の ShipMap を保持しているが、
+        // 差し替え後の ShipMap (map) も同じ ShipCollection.get().getShipMap() を参照しており、
+        // 常に before == map となっていたため cond 値の差を計算しても常に同じ値だったため。
+        // しかし、実際正しく動いていたとした場合、ここにたどり着くのは出撃途中の戦闘後になるので、
+        // cond 値は自然回復以外にも変動する可能性がある。
+        // 以上の理由からここで setCondUpdateTime() を更新するコードは削除する。
+//        Predicate<Ship> update = beforeShip -> {
+//            Ship afterShip = map.get(beforeShip.getId());
+//            if (afterShip != null) {
+//                return !beforeShip.getCond().equals(afterShip.getCond());
+//            }
+//            return false;
+//        };
+//        if (before.values().stream()
+//                .filter(ship -> ship.getCond() <= 49)
+//                .anyMatch(update)) {
+//            ZonedDateTime time = ZonedDateTime.now(ZoneId.systemDefault());
+//            AppCondition.get().setCondUpdateTime(time.toEpochSecond());
+//        }
     }
 
     /**


### PR DESCRIPTION
#### 問題解析
#140 で報告にあるように、cond値が49未満の艦がいるのに疲労回復予定時刻が表示されない、または大きくずれた時間が表示されることがある。原因を調べたところ、問題となるのは出撃後に母港に帰投したとき、本来なら更新されるべき `AppCondition.condUpdateTime` が更新されず、結果として自然回復予想量が実際より多く計算されるため表示されなかったり実際より早い予想時刻が表示されたりする。

#### 変更内容
問題となっていたのは `ApiPortPort` で艦の cond 値が変化したかを調べている箇所で、Port での更新を反映する前と後で cond 値を調べているが、反映する前に cond 値が 49 以下だった艦のみチェックするようになっていた。その場合、以下の条件を満たしてしまうと cond 値の変化はなかった＝condUpdateTimeの更新はしないことになる。
- 出撃艦隊に属していない艦の中に cond  値が49未満の艦がいない（＝自然回復する艦がいない）
- 出撃艦隊に属している艦が帰投する直前、 cond 値が全艦50以上
  - 帰投する直前の cond 値は最後に `ApiGetMemberShipDeck` で更新された値なので、帰投直前の戦闘を除いた最後の戦闘が終わり、進撃を選んだ直後の値になる。全艦49以上で出撃してS勝利をとると50以上となってこの条件を満たす。
- 帰投した後所属していた艦の中に（出撃で-15されることによって） cond 値が49未満の艦がいる

修正は単純に全ての艦について cond 値の変化をチェックするようにした。この場合自然回復以外にも出撃やcond値40未満の艦の入渠、演習等でも `condUpdateTime` がリセットされることになるが、艦これの仕様上自然回復の起点となる時間が取得できないことと、ずれていても実際の自然回復タイミングとのずれは最大3分となるので許容できると判断した。

また、 `ApiGetMemberShipDeck` でも同様のチェックを行うように実装されていたが、 `ApiGetMemberShipDeck` は出撃中に出撃している艦隊の艦についてのみ情報が送られてくるAPIで、出撃中のcond値は自然回復と無関係に変化して行くため、こちらでのチェックは行わないようにした。

Fixes #140 