### PR TITLE
連合編成時に第二艦隊を未遠征扱いにしない

### DIFF
--- a/src/main/java/logbook/api/ApiReqHenseiCombined.java
+++ b/src/main/java/logbook/api/ApiReqHenseiCombined.java
@@ -1,0 +1,29 @@
+package logbook.api;
+
+import java.util.Optional;
+
+import javax.json.JsonObject;
+
+import logbook.bean.AppCondition;
+import logbook.proxy.RequestMetaData;
+import logbook.proxy.ResponseMetaData;
+
+/**
+ * /kcsapi/api_req_hensei/combined
+ *
+ */
+@API("/kcsapi/api_req_hensei/combined")
+public class ApiReqHenseiCombined implements APIListenerSpi {
+
+    @Override
+    public void accept(JsonObject json, RequestMetaData req, ResponseMetaData res) {
+        Optional.ofNullable(req.getParameter("api_combined_type"))
+            .map(Integer::valueOf)
+            .ifPresent(type -> {
+                AppCondition app = AppCondition.get();
+                app.setCombinedType(type);
+                app.setCombinedFlag(type != 0);
+            });
+    }
+
+}

--- a/src/main/java/logbook/bean/BattleTypes.java
+++ b/src/main/java/logbook/bean/BattleTypes.java
@@ -1543,10 +1543,10 @@ public class BattleTypes {
 
     /**
      * 連合艦隊
-     * 0=未結成, 1=機動部隊, 2=水上部隊, 3=輸送部隊
+     * 0=未結成, 1=機動部隊, 2=水上部隊, 3=輸送部隊, (4, 5 - 念のため定義のみ）
      */
     public enum CombinedType {
-        未結成, 機動部隊, 水上部隊, 輸送部隊;
+        未結成, 機動部隊, 水上部隊, 輸送部隊, 連合艦隊タイプ4, 連合艦隊タイプ5;
 
         public static CombinedType toCombinedType(int i) {
             switch (i) {
@@ -1558,6 +1558,10 @@ public class BattleTypes {
                 return 水上部隊;
             case 3:
                 return 輸送部隊;
+            case 4:
+                return 連合艦隊タイプ4;
+            case 5:
+                return 連合艦隊タイプ5;
             default:
                 return 未結成;
             }

--- a/src/main/java/logbook/internal/gui/FleetTabPane.java
+++ b/src/main/java/logbook/internal/gui/FleetTabPane.java
@@ -64,6 +64,9 @@ public class FleetTabPane extends ScrollPane {
     /** 入渠中の艦娘達のハッシュ・コード */
     private int ndocksHashCode;
 
+    /** 連合艦隊フラグ */
+    private boolean combinedFlag;
+
     /** Tabのクラス名(タブ色を変えるのに使用) */
     private String tabCssClass;
 
@@ -236,12 +239,13 @@ public class FleetTabPane extends ScrollPane {
         int ndocksHashCode = NdockCollection.get().getNdockSet().hashCode();
 
         if (this.portHashCode != this.port.hashCode() || this.shipsHashCode != this.shipList.hashCode()
-                || this.ndocksHashCode != ndocksHashCode) {
+                || this.ndocksHashCode != ndocksHashCode || this.combinedFlag != AppCondition.get().isCombinedFlag()) {
             this.updateShips();
+            this.portHashCode = this.port.hashCode();
+            this.shipsHashCode = this.shipList.hashCode();
+            this.ndocksHashCode = ndocksHashCode;
+            this.combinedFlag = AppCondition.get().isCombinedFlag();
         }
-        this.portHashCode = this.port.hashCode();
-        this.shipsHashCode = this.shipList.hashCode();
-        this.ndocksHashCode = ndocksHashCode;
     }
 
     /**
@@ -323,7 +327,7 @@ public class FleetTabPane extends ScrollPane {
                         !ship.getBull().equals(Ships.shipMst(ship).map(ShipMst::getBullMax).orElse(0)))) {
             // 未補給時
             this.tabCssClass = "shortage";
-        } else if (this.port.getId() > 1 && this.port.getMission().get(0) == 0L) {
+        } else if (this.port.getId() > 1 && this.port.getMission().get(0) == 0L && (this.port.getId() != 2 || !AppCondition.get().isCombinedFlag())) {
             // 遠征未出撃
             this.tabCssClass = "empty";
         } else {

--- a/src/main/java/logbook/internal/gui/MissionPane.java
+++ b/src/main/java/logbook/internal/gui/MissionPane.java
@@ -14,6 +14,8 @@ import javafx.fxml.FXMLLoader;
 import javafx.scene.control.Label;
 import javafx.scene.control.ProgressBar;
 import javafx.scene.layout.AnchorPane;
+import logbook.bean.AppCondition;
+import logbook.bean.BattleTypes.CombinedType;
 import logbook.bean.DeckPort;
 import logbook.bean.Mission;
 import logbook.bean.MissionCollection;
@@ -118,12 +120,23 @@ public class MissionPane extends AnchorPane {
             this.progress.setVisible(false);
             // 艦隊名
             this.fleet.setText(this.port.getName());
-            // 遠征先
-            this.name.setText("<未出撃>");
-            // 残り時間
-            this.time.setText("");
-
-            styleClass.add("empty");
+            if (AppCondition.get().isCombinedFlag() && this.port.getId() == 2) {
+                // 連合編成中
+                this.name.setText("(連合艦隊)");
+                this.time.setText(
+                        Optional.of(AppCondition.get().getCombinedType())
+                            .map(CombinedType::toCombinedType)
+                            .filter(type -> type != CombinedType.未結成)
+                            .map(CombinedType::toString)
+                            .orElse("<不明な連合艦隊タイプ>")
+                 );
+            } else {
+                // 遠征先
+                this.name.setText("<未出撃>");
+                styleClass.add("empty");
+                // 残り時間
+                this.time.setText("");
+            }
         } else {
             // 出撃(遠征中・遠征帰還・遠征中止)
             Optional<Mission> mission = Optional.ofNullable(MissionCollection.get()

--- a/src/main/resources/META-INF/services/logbook.api.APIListenerSpi
+++ b/src/main/resources/META-INF/services/logbook.api.APIListenerSpi
@@ -30,6 +30,7 @@ logbook.api.ApiReqCombinedBattleLdAirbattle
 logbook.api.ApiReqCombinedBattleMidnightBattle
 logbook.api.ApiReqCombinedBattleSpMidnight
 logbook.api.ApiReqHenseiChange
+logbook.api.ApiReqHenseiCombined
 logbook.api.ApiReqHenseiPresetSelect
 logbook.api.ApiReqHokyuCharge
 logbook.api.ApiReqKaisouMarriage


### PR DESCRIPTION
#### 変更内容
- `/kcsapi/api_req_hensei/combined` の listener を登録し、連合艦隊の変更を即座に反映
- 遠征ペインにおいて連合艦隊編成時には第二艦隊を「未遠征」ではなく「（連合艦隊）」にして種別を表示
- 艦隊タブで連合艦隊編成時には第二艦隊を未遠征（青）ではなく第一艦隊同様の扱いに変更
- （将来第四の連合艦隊種別が出た時に「未結成」にならないように generic な名前を登録）