### PR TITLE
南西諸島沖両方(1-2, 48-2)に出撃した場合に両方の出撃としてカウントされるのを修正

### DIFF
--- a/src/main/java/logbook/internal/BattleLogs.java
+++ b/src/main/java/logbook/internal/BattleLogs.java
@@ -433,10 +433,10 @@ public class BattleLogs {
      * @param bossOnly 集計対象をボスのみにする場合true
      * @return 出撃統計
      */
-    public static BattleLogCollect collect(List<SimpleBattleLog> logs, String area, boolean bossOnly) {
+    public static BattleLogCollect collect(List<SimpleBattleLog> logs, String areaShortName, boolean bossOnly) {
         Predicate<SimpleBattleLog> anyFilter = e -> true;
         // 海域フィルタ
-        Predicate<SimpleBattleLog> areaFilter = area != null ? e -> area.equals(e.getArea()) : anyFilter;
+        Predicate<SimpleBattleLog> areaFilter = areaShortName != null ? e -> areaShortName.equals(e.getAreaShortName()) : anyFilter;
         // ボスフィルタ
         Predicate<SimpleBattleLog> bossFilter = bossOnly ? e -> e.getBoss().indexOf("ボス") != -1 : anyFilter;
 

--- a/src/main/java/logbook/internal/gui/BattleLogController.java
+++ b/src/main/java/logbook/internal/gui/BattleLogController.java
@@ -378,7 +378,7 @@ public class BattleLogController extends WindowController {
             }
 
             // 海域毎の集計
-            BattleLogCollect areaValue = BattleLogs.collect(list, area, false);
+            BattleLogCollect areaValue = BattleLogs.collect(list, name.getValue(), false);
             areaValue.setUnit(text);
             areaValue.setCollectUnit(unit);
             areaValue.setArea(area);


### PR DESCRIPTION
#### 問題解析
#174 にて同じ海域名をもつ海域（1-2 及び 48-2）の CSV への記録方法を変更し、データ上は海域の区別が可能になったが、戦闘ログにおいて重複する現象が見受けられた。例えば同日に1-2に1回、48-2に1回出撃すると、それぞれ2回としてカウントされていた。原因は、対象期間内のすべての出撃ログに対し海域名でのマップを作成し、そのマップのエントリに対して該当するログをカウントしていたことによる。

#### 修正内容
- 海域名をキーにしてカウントするのではなく、短縮名（`1-2`など）でカウントするように変更