### PR TITLE
戦闘ログの集計ビューをソート可能＆カラム幅・ソート順を記憶する

### DIFF
--- a/src/main/java/logbook/internal/BattleLogs.java
+++ b/src/main/java/logbook/internal/BattleLogs.java
@@ -459,21 +459,21 @@ public class BattleLogs {
                 .filter(bossFilter)
                 .map(SimpleBattleLog::getRank)
                 .collect(Collectors.groupingBy(s -> s, Collectors.counting()));
-        long s = rank.getOrDefault("S", 0L);
-        long a = rank.getOrDefault("A", 0L);
-        long b = rank.getOrDefault("B", 0L);
-        long c = rank.getOrDefault("C", 0L);
-        long d = rank.getOrDefault("D", 0L);
-        long win = s + a + b;
+        int s = rank.getOrDefault("S", 0L).intValue();
+        int a = rank.getOrDefault("A", 0L).intValue();
+        int b = rank.getOrDefault("B", 0L).intValue();
+        int c = rank.getOrDefault("C", 0L).intValue();
+        int d = rank.getOrDefault("D", 0L).intValue();
+        int win = s + a + b;
 
         BattleLogCollect value = new BattleLogCollect();
         value.setStart(start);
-        value.setWin(String.valueOf(win));
-        value.setS(String.valueOf(s));
-        value.setA(String.valueOf(a));
-        value.setB(String.valueOf(b));
-        value.setC(String.valueOf(c));
-        value.setD(String.valueOf(d));
+        value.setWin(win);
+        value.setS(s);
+        value.setA(a);
+        value.setB(b);
+        value.setC(c);
+        value.setD(d);
         return value;
     }
 
@@ -484,13 +484,26 @@ public class BattleLogs {
 
     private static void updateLog(Map<String, String> mapNames, SimpleBattleLog log) {
         String shortName = log.getAreaShortName() != null ? log.getAreaShortName() : mapNames.get(log.getArea());
+        int sortOrder = Integer.MAX_VALUE;
         if (shortName != null) {
             log.setAreaShortName(shortName);
             String cell = Mapping.getCell(shortName + "-" + log.getCell());
             if (cell != null) {
                 log.setCell(cell);
             }
+            Pattern AREA_SHORTNAME_PATTERN = Pattern.compile("^([0-9]+)-([0-9]+)$");
+            Matcher m = AREA_SHORTNAME_PATTERN.matcher(shortName);
+            if (m.matches()) {
+                try {
+                    int area = Integer.parseInt(m.group(1));
+                    int no = Integer.parseInt(m.group(2));
+                    sortOrder = area * 1000000 + no * 1000 + Integer.parseInt(cell);
+                } catch (Throwable e) {
+                    // ignore parse error
+                }
+            }
         }
+        log.setAreaSortOrder(sortOrder);
     }
 
     /**
@@ -508,6 +521,8 @@ public class BattleLogs {
         private String area;
         /** 海域略称 */
         private String areaShortName;
+        /** 海域の並び替え順 */
+        private int areaSortOrder;
         /** マス */
         private String cell;
         /** ボス */

--- a/src/main/java/logbook/internal/gui/BattleLogCollect.java
+++ b/src/main/java/logbook/internal/gui/BattleLogCollect.java
@@ -1,5 +1,7 @@
 package logbook.internal.gui;
 
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.SimpleIntegerProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import logbook.internal.BattleLogs.IUnit;
@@ -11,28 +13,28 @@ import logbook.internal.BattleLogs.IUnit;
 public class BattleLogCollect {
 
     /** 集計  */
-    private StringProperty unit;
+    private final StringProperty unit = new SimpleStringProperty();
 
-    /** 出撃  */
-    private StringProperty start;
+    /** 出撃 （ボスカウントを"-"にするため String のままにする） */
+    private final SimpleStringProperty start = new SimpleStringProperty();
 
     /** 勝利  */
-    private StringProperty win;
+    private final IntegerProperty win = new SimpleIntegerProperty();
 
     /** S勝利 */
-    private StringProperty s;
+    private final IntegerProperty s = new SimpleIntegerProperty();
 
     /** A勝利 */
-    private StringProperty a;
+    private final IntegerProperty a = new SimpleIntegerProperty();
 
     /** B勝利 */
-    private StringProperty b;
+    private final IntegerProperty b = new SimpleIntegerProperty();
 
     /** C敗北 */
-    private StringProperty c;
+    private final IntegerProperty c = new SimpleIntegerProperty();
 
     /** D敗北 */
-    private StringProperty d;
+    private final IntegerProperty d = new SimpleIntegerProperty();
 
     /** 集計単位 */
     private IUnit collectUnit;
@@ -46,6 +48,9 @@ public class BattleLogCollect {
     /** ボス */
     private boolean boss;
 
+    /** 海域ソート順 */
+    private int areaSortOrder;
+    
     /**
      * 集計を取得します。
      * @return 集計
@@ -59,7 +64,7 @@ public class BattleLogCollect {
      * @param unit 集計
      */
     public void setUnit(String unit) {
-        this.unit = new SimpleStringProperty(unit);
+        this.unit.set(unit);
     }
 
     /**
@@ -83,7 +88,7 @@ public class BattleLogCollect {
      * @param start 出撃
      */
     public void setStart(String start) {
-        this.start = new SimpleStringProperty(start);
+        this.start .set(start);
     }
 
     /**
@@ -98,7 +103,7 @@ public class BattleLogCollect {
      * 勝利を取得します。
      * @return 勝利
      */
-    public String getWin() {
+    public int getWin() {
         return this.win.get();
     }
 
@@ -106,15 +111,15 @@ public class BattleLogCollect {
      * 勝利を設定します。
      * @param win 勝利
      */
-    public void setWin(String win) {
-        this.win = new SimpleStringProperty(win);
+    public void setWin(int win) {
+        this.win.set(win);
     }
 
     /**
      * 勝利を取得します。
      * @return 勝利
      */
-    public StringProperty winProperty() {
+    public IntegerProperty winProperty() {
         return this.win;
     }
 
@@ -122,7 +127,7 @@ public class BattleLogCollect {
      * S勝利を取得します。
      * @return S勝利
      */
-    public String getS() {
+    public int getS() {
         return this.s.get();
     }
 
@@ -130,15 +135,15 @@ public class BattleLogCollect {
      * S勝利を設定します。
      * @param s S勝利
      */
-    public void setS(String s) {
-        this.s = new SimpleStringProperty(s);
+    public void setS(int s) {
+        this.s.set(s);
     }
 
     /**
      * S勝利を取得します。
      * @return S勝利
      */
-    public StringProperty sProperty() {
+    public IntegerProperty sProperty() {
         return this.s;
     }
 
@@ -146,7 +151,7 @@ public class BattleLogCollect {
      * A勝利を取得します。
      * @return A勝利
      */
-    public String getA() {
+    public int getA() {
         return this.a.get();
     }
 
@@ -154,15 +159,15 @@ public class BattleLogCollect {
      * A勝利を設定します。
      * @param a A勝利
      */
-    public void setA(String a) {
-        this.a = new SimpleStringProperty(a);
+    public void setA(int a) {
+        this.a.set(a);
     }
 
     /**
      * A勝利を取得します。
      * @return A勝利
      */
-    public StringProperty aProperty() {
+    public IntegerProperty aProperty() {
         return this.a;
     }
 
@@ -170,7 +175,7 @@ public class BattleLogCollect {
      * B勝利を取得します。
      * @return B勝利
      */
-    public String getB() {
+    public int getB() {
         return this.b.get();
     }
 
@@ -178,15 +183,15 @@ public class BattleLogCollect {
      * B勝利を設定します。
      * @param b B勝利
      */
-    public void setB(String b) {
-        this.b = new SimpleStringProperty(b);
+    public void setB(int b) {
+        this.b.set(b);
     }
 
     /**
      * B勝利を取得します。
      * @return B勝利
      */
-    public StringProperty bProperty() {
+    public IntegerProperty bProperty() {
         return this.b;
     }
 
@@ -194,7 +199,7 @@ public class BattleLogCollect {
      * C敗北を取得します。
      * @return C敗北
      */
-    public String getC() {
+    public int getC() {
         return this.c.get();
     }
 
@@ -202,15 +207,15 @@ public class BattleLogCollect {
      * C敗北を設定します。
      * @param c C敗北
      */
-    public void setC(String c) {
-        this.c = new SimpleStringProperty(c);
+    public void setC(int c) {
+        this.c.set(c);
     }
 
     /**
      * C敗北を取得します。
      * @return C敗北
      */
-    public StringProperty cProperty() {
+    public IntegerProperty cProperty() {
         return this.c;
     }
 
@@ -218,7 +223,7 @@ public class BattleLogCollect {
      * D敗北を取得します。
      * @return D敗北
      */
-    public String getD() {
+    public int getD() {
         return this.d.get();
     }
 
@@ -226,15 +231,15 @@ public class BattleLogCollect {
      * D敗北を設定します。
      * @param d D敗北
      */
-    public void setD(String d) {
-        this.d = new SimpleStringProperty(d);
+    public void setD(int d) {
+        this.d.set(d);
     }
 
     /**
      * D敗北を取得します。
      * @return D敗北
      */
-    public StringProperty dProperty() {
+    public IntegerProperty dProperty() {
         return this.d;
     }
 
@@ -300,5 +305,21 @@ public class BattleLogCollect {
      */
     public void setBoss(boolean boss) {
         this.boss = boss;
+    }
+
+    /**
+     * 海域ソート順を取得します。
+     * @return ソート順
+     */
+    public int getAreaSortOrder() {
+        return this.areaSortOrder;
+    }
+
+    /**
+     * 海域ソート順を設定します。
+     * @param areaSortOrder ソート順
+     */
+    public void setAreaSortOrder(int areaSortOrder) {
+        this.areaSortOrder = areaSortOrder;
     }
 }

--- a/src/main/java/logbook/internal/gui/BattleLogController.java
+++ b/src/main/java/logbook/internal/gui/BattleLogController.java
@@ -356,6 +356,7 @@ public class BattleLogController extends WindowController {
                 });
                 return true;
             });
+
             // 集計
             this.aggregate.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
             this.aggregate.setOnKeyPressed(TableTool::defaultOnKeyPressedHandler);
@@ -373,6 +374,8 @@ public class BattleLogController extends WindowController {
 
             // フィルタ
             this.initializeFilterPane();
+
+            TreeTableTool.setVisible(this.collect, this.getClass().toString() + "#" + "collect");
         } catch (Exception e) {
             LoggerHolder.get().error("FXMLの初期化に失敗しました", e);
         }

--- a/src/main/java/logbook/internal/gui/BattleLogDetail.java
+++ b/src/main/java/logbook/internal/gui/BattleLogDetail.java
@@ -3,6 +3,8 @@ package logbook.internal.gui;
 import java.time.ZoneId;
 import java.util.StringJoiner;
 
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.SimpleIntegerProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import logbook.internal.BattleLogs.SimpleBattleLog;
@@ -47,9 +49,9 @@ public class BattleLogDetail {
     /** ドロップアイテム */
     private StringProperty dropItem;
     /** 艦娘経験値 */
-    private StringProperty shipExp;
+    private final IntegerProperty shipExp = new SimpleIntegerProperty();
     /** 提督経験値 */
-    private StringProperty exp;
+    private final IntegerProperty exp = new SimpleIntegerProperty();
 
     /**
      * 日付を取得します。
@@ -439,7 +441,7 @@ public class BattleLogDetail {
      * 艦娘経験値を取得します。
      * @return 艦娘経験値
      */
-    public String getShipExp() {
+    public int getShipExp() {
         return this.shipExp.get();
     }
 
@@ -447,15 +449,15 @@ public class BattleLogDetail {
      * 艦娘経験値を設定します。
      * @param shipExp 艦娘経験値
      */
-    public void setShipExp(String shipExp) {
-        this.shipExp = new SimpleStringProperty(shipExp);
+    public void setShipExp(int shipExp) {
+        this.shipExp.set(shipExp);
     }
 
     /**
      * 艦娘経験値を取得します。
      * @return 艦娘経験値
      */
-    public StringProperty shipExpProperty() {
+    public IntegerProperty shipExpProperty() {
         return this.shipExp;
     }
 
@@ -463,7 +465,7 @@ public class BattleLogDetail {
      * 提督経験値を取得します。
      * @return 提督経験値
      */
-    public String getExp() {
+    public int getExp() {
         return this.exp.get();
     }
 
@@ -471,15 +473,15 @@ public class BattleLogDetail {
      * 提督経験値を設定します。
      * @param exp 提督経験値
      */
-    public void setExp(String exp) {
-        this.exp = new SimpleStringProperty(exp);
+    public void setExp(int exp) {
+        this.exp.set(exp);
     }
 
     /**
      * 提督経験値を取得します。
      * @return 提督経験値
      */
-    public StringProperty expProperty() {
+    public IntegerProperty expProperty() {
         return this.exp;
     }
 
@@ -501,8 +503,8 @@ public class BattleLogDetail {
                 .add(this.dropType.get())
                 .add(this.dropShip.get())
                 .add(this.dropItem.get())
-                .add(this.shipExp.get())
-                .add(this.exp.get())
+                .add(Integer.toString(this.shipExp.get()))
+                .add(Integer.toString(this.exp.get()))
                 .toString();
     }
 
@@ -532,8 +534,8 @@ public class BattleLogDetail {
         detail.setDropType(log.getDropType());
         detail.setDropShip(log.getDropShip());
         detail.setDropItem(log.getDropItem());
-        detail.setShipExp(log.getShipExp());
-        detail.setExp(log.getExp());
+        detail.setShipExp(Integer.parseInt(log.getShipExp()));
+        detail.setExp(Integer.parseInt(log.getExp()));
         return detail;
     }
 }

--- a/src/main/java/logbook/internal/gui/Tools.java
+++ b/src/main/java/logbook/internal/gui/Tools.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.StringJoiner;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -23,6 +24,7 @@ import javax.imageio.ImageIO;
 
 import org.controlsfx.control.Notifications;
 
+import javafx.beans.property.ObjectProperty;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.embed.swing.SwingFXUtils;
@@ -40,6 +42,8 @@ import javafx.scene.control.TableColumn.SortType;
 import javafx.scene.control.TableColumnBase;
 import javafx.scene.control.TableView;
 import javafx.scene.control.TextArea;
+import javafx.scene.control.TreeTableColumn;
+import javafx.scene.control.TreeTableView;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.image.WritableImage;
@@ -284,11 +288,173 @@ public class Tools {
         }
     }
 
+    public static class TablesTreesBase {
+
+        /**
+         * テーブル列の幅の設定を行う
+         * @param table テーブル
+         * @param key テーブルのキー名
+         */
+        public static  <S> void setWidth(Supplier<Stream<? extends TableColumnBase<S, ?>>> columns, String key) {
+            Map<String, Double> setting = AppConfig.get()
+                    .getColumnWidthMap()
+                    .get(key);
+            if (setting != null) {
+                // 初期設定
+                columns.get().forEach(column -> {
+                    Double width = setting.get(getColumnName(column));
+                    if (width != null) {
+                        column.setPrefWidth(width);
+                    }
+                });
+            }
+            // 幅が変更された時に設定を保存する
+            columns.get().forEach(column -> {
+                column.widthProperty().addListener((ob, o, n) -> {
+                    Map<String, Double> map = AppConfig.get()
+                            .getColumnWidthMap()
+                            .computeIfAbsent(key, e -> new HashMap<>());
+                    map.put(getColumnName(column), n.doubleValue());
+                });
+            });
+        }
+
+        public interface AbstractTable<S, C extends TableColumnBase<?, ?>> {
+            public Stream<C> getColumns();
+            public ObservableList<C> getSortOrder();
+            public String getSortType(C column);
+            public void setSortType(C column, String type);
+            public ObjectProperty<?> sortTypeProperty(C column);
+        }
+        
+        public static class TableWrapper<S> implements AbstractTable<S, TableColumn<S, ?>> {
+            private final TableView<S> table;
+            TableWrapper(TableView<S> table) {
+                this.table = table;
+            }
+            
+            @Override
+            public Stream<TableColumn<S, ?>> getColumns() {
+                return Tables.getColumns(this.table);
+            }
+
+            @Override
+            public ObservableList<TableColumn<S, ?>> getSortOrder() {
+                return this.table.getSortOrder();
+            }
+
+            @Override
+            public void setSortType(TableColumn<S, ?> column, String type) {
+                column.setSortType(SortType.valueOf(type));
+            }
+
+            @Override
+            public ObjectProperty<?> sortTypeProperty(TableColumn<S, ?> column) {
+                return column.sortTypeProperty();
+            }
+
+            @Override
+            public String getSortType(TableColumn<S, ?> column) {
+                return column.getSortType().name();
+            }
+        }
+
+        public static class TreeWrapper<S> implements AbstractTable<S, TreeTableColumn<S, ?>> {
+            private final TreeTableView<S> tree;
+            TreeWrapper(TreeTableView<S> table) {
+                this.tree = table;
+            }
+            
+            @Override
+            public Stream<TreeTableColumn<S, ?>> getColumns() {
+                return Trees.getColumns(this.tree);
+            }
+
+            @Override
+            public ObservableList<TreeTableColumn<S, ?>> getSortOrder() {
+                return this.tree.getSortOrder();
+            }
+
+            @Override
+            public String getSortType(TreeTableColumn<S, ?> column) {
+                return column.getSortType().name();
+            }
+
+            @Override
+            public void setSortType(TreeTableColumn<S, ?> column, String type) {
+                column.setSortType(TreeTableColumn.SortType.valueOf(type));
+            }
+
+            @Override
+            public ObjectProperty<?> sortTypeProperty(TreeTableColumn<S, ?> column) {
+                return column.sortTypeProperty();
+            }
+        }
+        
+        /**
+         * テーブルソート列の設定を行う
+         * @param table テーブル
+         * @param key テーブルのキー名
+         */
+        public static <S, C extends TableColumnBase<?, ?>> void setSortOrder(AbstractTable<S, C> table, String key) {
+            Map<String, String> setting = AppConfig.get()
+                    .getColumnSortOrderMap()
+                    .get(key);
+            ObservableList<C> sortOrder = table.getSortOrder();
+            if (setting != null) {
+                // 初期設定
+                Map<String, C> columnsMap = table.getColumns()
+                        .collect(Collectors.toMap(Tables::getColumnName, c -> c, (c1, c2) -> c1));
+                setting.forEach((k, v) -> {
+                    Optional.ofNullable(columnsMap.get(k)).ifPresent(col -> {
+                        sortOrder.add(col);
+                        table.setSortType(col, v);
+                    });
+                });
+            }
+            // ソート列またはソートタイプが変更された時に設定を保存する
+            sortOrder.addListener((ListChangeListener<C>) e -> storeSortOrder(table, key));
+            table.getColumns().forEach(col -> {
+                table.sortTypeProperty(col).addListener((ob, o, n) -> storeSortOrder(table, key));
+            });
+        }
+
+        private static <S, C extends TableColumnBase<?, ?>> void storeSortOrder(AbstractTable<S, C> table, String key) {
+            ObservableList<C> sortOrder = table.getSortOrder();
+            Map<String, String> setting = AppConfig.get()
+                    .getColumnSortOrderMap()
+                    .computeIfAbsent(key, e1 -> new LinkedHashMap<>());
+            setting.clear();
+            sortOrder.stream().forEach(col -> setting.put(getColumnName(col), table.getSortType(col)));
+        }
+        
+        /**
+         * TableColumnの名前を取得する
+         * @param column TableColumn
+         * @return TableColumnの名前
+         */
+        public static String getColumnName(TableColumnBase<?, ?> column) {
+            LinkedList<String> names = null;
+            TableColumnBase<?, ?> parent = column;
+            while ((parent = parent.getParentColumn()) != null) {
+                if (names == null) {
+                    names = new LinkedList<>();
+                }
+                names.addFirst(parent.getText());
+            }
+            if (names != null) {
+                return names.stream().collect(Collectors.joining(".")) + "." + column.getText();
+            } else {
+                return column.getText();
+            }
+        }
+    }
+    
     /**
      * TableViewに関係するメソッドを集めたクラス
      *
      */
-    public static class Tables {
+    public static class Tables extends TablesTreesBase {
 
         private static final String SEPARATOR = "\t"; //$NON-NLS-1$
 
@@ -429,27 +595,7 @@ public class Tools {
          * @param key テーブルのキー名
          */
         public static void setWidth(TableView<?> table, String key) {
-            Map<String, Double> setting = AppConfig.get()
-                    .getColumnWidthMap()
-                    .get(key);
-            if (setting != null) {
-                // 初期設定
-                getColumns(table).forEach(column -> {
-                    Double width = setting.get(getColumnName(column));
-                    if (width != null) {
-                        column.setPrefWidth(width);
-                    }
-                });
-            }
-            // 幅が変更された時に設定を保存する
-            getColumns(table).forEach(column -> {
-                column.widthProperty().addListener((ob, o, n) -> {
-                    Map<String, Double> map = AppConfig.get()
-                            .getColumnWidthMap()
-                            .computeIfAbsent(key, e -> new HashMap<>());
-                    map.put(getColumnName(column), n.doubleValue());
-                });
-            });
+            TablesTreesBase.setWidth(() -> getColumns(table), key);
         }
 
         /**
@@ -458,47 +604,7 @@ public class Tools {
          * @param key テーブルのキー名
          */
         public static <S> void setSortOrder(TableView<S> table, String key) {
-            Map<String, String> setting = AppConfig.get()
-                    .getColumnSortOrderMap()
-                    .get(key);
-            ObservableList<TableColumn<S, ?>> sortOrder = table.getSortOrder();
-            if (setting != null) {
-                // 初期設定
-                Map<String, TableColumn<S, ?>> columnsMap = getColumns(table)
-                        .collect(Collectors.toMap(Tables::getColumnName, c -> c, (c1, c2) -> c1));
-                setting.forEach((k, v) -> {
-                    Optional.ofNullable(columnsMap.get(k)).ifPresent(col -> {
-                        sortOrder.add(col);
-                        col.setSortType(SortType.valueOf(v));
-                    });
-                });
-            }
-            // ソート列またはソートタイプが変更された時に設定を保存する
-            sortOrder.addListener((ListChangeListener<TableColumn<S, ?>>) e -> storeSortOrder(table, key));
-            getColumns(table).forEach(col -> {
-                col.sortTypeProperty().addListener((ob, o, n) -> storeSortOrder(table, key));
-            });
-        }
-
-        /**
-         * TableColumnの名前を取得する
-         * @param column TableColumn
-         * @return TableColumnの名前
-         */
-        public static String getColumnName(TableColumn<?, ?> column) {
-            LinkedList<String> names = null;
-            TableColumnBase<?, ?> parent = column;
-            while ((parent = parent.getParentColumn()) != null) {
-                if (names == null) {
-                    names = new LinkedList<>();
-                }
-                names.addFirst(parent.getText());
-            }
-            if (names != null) {
-                return names.stream().collect(Collectors.joining(".")) + "." + column.getText();
-            } else {
-                return column.getText();
-            }
+            TablesTreesBase.setSortOrder(new TableWrapper<S>(table), key);
         }
 
         /**
@@ -510,15 +616,6 @@ public class Tools {
             return table.getColumns()
                     .stream()
                     .flatMap(Tables::flatColumns);
-        }
-
-        private static <S> void storeSortOrder(TableView<S> table, String key) {
-            ObservableList<TableColumn<S, ?>> sortOrder = table.getSortOrder();
-            Map<String, String> setting = AppConfig.get()
-                    .getColumnSortOrderMap()
-                    .computeIfAbsent(key, e1 -> new LinkedHashMap<>());
-            setting.clear();
-            sortOrder.stream().forEach(col -> setting.put(getColumnName(col), col.getSortType().name()));
         }
 
         private static String tableHeader(TableView<?> table, String separator) {
@@ -539,6 +636,35 @@ public class Tools {
                         .flatMap(Tables::flatColumns);
             }
             return Stream.of(column);
+        }
+    }
+    
+    public static class Trees extends TablesTreesBase {
+        /**
+         * テーブル列の幅の設定を行う
+         * @param table テーブル
+         * @param key テーブルのキー名
+         */
+        public static void setWidth(TreeTableView<?> tree, String key) {
+            TablesTreesBase.setWidth(() -> getColumns(tree), key);
+        }
+        
+        /**
+         * テーブルソート列の設定を行う
+         * @param table テーブル
+         * @param key テーブルのキー名
+         */
+        public static <S> void setSortOrder(TreeTableView<S> table, String key) {
+            TablesTreesBase.setSortOrder(new TreeWrapper<S>(table), key);
+        }
+
+        /**
+         * TreeTableViewからTreeTableColumnをストリームとして取得する
+         * @param tree TreeTableView
+         * @return TreeTableColumn
+         */
+        public static <S> Stream<TreeTableColumn<S, ?>> getColumns(TreeTableView<S> tree) {
+            return tree.getColumns().stream();
         }
     }
 

--- a/src/main/java/logbook/internal/gui/TreeTableTool.java
+++ b/src/main/java/logbook/internal/gui/TreeTableTool.java
@@ -1,0 +1,16 @@
+package logbook.internal.gui;
+
+import javafx.scene.control.TreeTableView;
+
+public class TreeTableTool {
+    /**
+     * テーブル列の表示・非表示の設定を行う
+     * @param table テーブル
+     * @param key テーブルのキー名
+     */
+    static void setVisible(TreeTableView<?> table, String key) {
+        //Tools.Trees.setVisible(table, key);   // not yet implemented
+        Tools.Trees.setWidth(table, key);
+        Tools.Trees.setSortOrder(table, key);
+    }
+}


### PR DESCRIPTION
#### 変更内容
戦闘ログについて、右側のテーブルに関してはソート可能でカラム幅やソート順も記録されていたが、左側のツリービューに関してはそれらが実装されていなかったので実装を行なった。

具体的には、sort policy をセットして、各カラムのソート順に応じて適宜ソートを行うようにした。もともとカウントのカラムも文字列型になっていたため、数値に変更し数字でソートされるように変更した。また、カラム幅とソート順の記録を行うユーティリティークラスはなかったので、テーブル用のクラスを一部 abstraction/wrap してツリーの場合にも適用できるように変更した。記録内容はテーブルと同じマップに入る。カラムの show/hide については簡単ではないためまだ実装していない。

結果として以下のような仕様となる：
- 集計カラムでは海域短縮名（`1-2`など）の **数値で** ソートされる。つまり4-5の次は5-1であり、48-1ではなくなる。
- 集計カラムでのソートは集計単位以下で行われる。「デイリー」「ウィークリー」等はソートされない。
- それ以外のカラムでは回数の数値でソートされる。出撃カラムのみボス（`-`表示）は0としてソートされる。
- 戦闘ログを閉じた時のカラム幅とソート順（複数も可）が記録され、次に開いた時にその順に表示される。（リセットはできない。）

#### 関連 Issue
#165 の一部
