### PR TITLE
海域ごとの集計キーに短縮名を使用

### DIFF
--- a/src/main/java/logbook/internal/gui/BattleLogCollect.java
+++ b/src/main/java/logbook/internal/gui/BattleLogCollect.java
@@ -40,6 +40,9 @@ public class BattleLogCollect {
     /** 海域 */
     private String area;
 
+    /** 海域短縮名 */
+    private String areaShortName;
+
     /** ボス */
     private boolean boss;
 
@@ -265,6 +268,22 @@ public class BattleLogCollect {
      */
     public void setArea(String area) {
         this.area = area;
+    }
+
+    /**
+     * 海域短縮名を取得します。
+     * @return 海域短縮名
+     */
+    public String getAreaShortName() {
+        return this.areaShortName;
+    }
+
+    /**
+     * 海域短縮名を設定します。
+     * @param areaShortName 海域短縮名
+     */
+    public void setAreaShortName(String areaShortName) {
+        this.areaShortName = areaShortName;
     }
 
     /**

--- a/src/main/java/logbook/internal/gui/BattleLogController.java
+++ b/src/main/java/logbook/internal/gui/BattleLogController.java
@@ -382,6 +382,7 @@ public class BattleLogController extends WindowController {
             areaValue.setUnit(text);
             areaValue.setCollectUnit(unit);
             areaValue.setArea(area);
+            areaValue.setAreaShortName(name.getValue());
 
             TreeItem<BattleLogCollect> areaRoot = new TreeItem<BattleLogCollect>(areaValue);
 
@@ -390,6 +391,7 @@ public class BattleLogController extends WindowController {
             areaBossValue.setUnit("ボス");
             areaBossValue.setCollectUnit(unit);
             areaBossValue.setArea(area);
+            areaBossValue.setAreaShortName(name.getValue());
             areaBossValue.setBoss(true);
 
             TreeItem<BattleLogCollect> areaBoss = new TreeItem<BattleLogCollect>(areaBossValue);
@@ -525,12 +527,12 @@ public class BattleLogController extends WindowController {
         this.detailsSource.clear();
         if (value != null) {
             BattleLogCollect collect = value.getValue();
-            String area = collect.getArea();
+            String areaShortName = collect.getAreaShortName();
             boolean boss = collect.isBoss();
 
             Predicate<BattleLogDetail> anyFilter = e -> true;
             // 海域フィルタ
-            Predicate<BattleLogDetail> areaFilter = area != null ? e -> area.equals(e.getArea()) : anyFilter;
+            Predicate<BattleLogDetail> areaFilter = areaShortName != null ? e -> areaShortName.equals(e.getAreaShortName()) : anyFilter;
             // ボスフィルタ
             Predicate<BattleLogDetail> bossFilter = boss ? e -> e.getBoss().indexOf("ボス") != -1 : anyFilter;
 
@@ -620,7 +622,7 @@ public class BattleLogController extends WindowController {
      * 集計を初期化する
      */
     private void initializeAggregate() {
-        this.addAggregate(this.area, BattleLogDetail::getArea);
+        this.addAggregate(this.area, (detail) -> detail.getAreaShortName() + " " + detail.getArea());
         this.addAggregate(this.cell, BattleLogDetail::getCell);
         this.addAggregate(this.boss, BattleLogDetail::getBoss);
         this.addAggregate(this.rank, BattleLogDetail::getRank);

--- a/src/main/java/logbook/internal/gui/BattleLogDetail.java
+++ b/src/main/java/logbook/internal/gui/BattleLogDetail.java
@@ -18,6 +18,8 @@ public class BattleLogDetail {
     private StringProperty date;
     /** 海域 */
     private StringProperty area;
+    /** 海域短縮名 */
+    private StringProperty areaShortName;
     /** マス */
     private StringProperty cell;
     /** ボス */
@@ -95,6 +97,30 @@ public class BattleLogDetail {
      */
     public StringProperty areaProperty() {
         return this.area;
+    }
+
+    /**
+     * 海域短縮名を取得します。
+     * @return 海域短縮名
+     */
+    public String getAreaShortName() {
+        return this.areaShortName.get();
+    }
+
+    /**
+     * 海域短縮名を設定します。
+     * @param area 海域短縮名
+     */
+    public void setAreaShortName(String area) {
+        this.areaShortName = new SimpleStringProperty(area);
+    }
+
+    /**
+     * 海域短縮名を取得します。
+     * @return 海域短縮名
+     */
+    public StringProperty areaShortNameProperty() {
+        return this.areaShortName;
     }
 
     /**
@@ -492,6 +518,7 @@ public class BattleLogDetail {
         String date = Logs.DATE_FORMAT.format(log.getDate().withZoneSameInstant(ZoneId.of("Asia/Tokyo")));
         detail.setDate(date);
         detail.setArea(log.getArea());
+        detail.setAreaShortName(log.getAreaShortName());
         detail.setCell(log.getCell());
         detail.setBoss(log.getBoss());
         detail.setRank(log.getRank());


### PR DESCRIPTION
#### 問題解析
戦闘ログビューで同じ集計単位（ウィークリーなど）に同一海域名である1-2と48-2の両方の出撃記録があると、それらの海域を選択した時、右のテーブルで両方のデータが表示されてしまう。これも他の変更と同様、やはり海域名でフィルターしていたため。また、右下の集計ビューで海域を選んだ時はこれも海域名で集計していたため同一の海域とみなされてカウントされていた。

#### 変更内容
- 左の海域を選んだ時、海域短縮名でフィルターするように変更
- 右下の集計ビューでは短縮名+海域名を使うように変更

