### PR TITLE
開発ログの改善

### DIFF
--- a/src/main/java/logbook/internal/gui/CreateItemController.java
+++ b/src/main/java/logbook/internal/gui/CreateItemController.java
@@ -170,6 +170,7 @@ public class CreateItemController extends WindowController {
             this.group.selectedToggleProperty()
                     .addListener(this::changeType);
             this.setCollect(this.buttonItemRecipe);
+            TreeTableTool.setVisible(this.collect, this.getClass() + "#" + "collect");
         } catch (Exception e) {
             LoggerHolder.get().error("FXMLの初期化に失敗しました", e);
         }

--- a/src/main/java/logbook/internal/gui/CreateItemController.java
+++ b/src/main/java/logbook/internal/gui/CreateItemController.java
@@ -373,12 +373,14 @@ public class CreateItemController extends WindowController {
     private void detail(ObservableValue<? extends TreeItem<CreateItemCollect>> observable,
             TreeItem<CreateItemCollect> oldValue, TreeItem<CreateItemCollect> value) {
         if (value != null) {
-            List<CreateItem> items = this.detailList.get(value.getValue());
             this.detailItems.clear();
-            if (items != null) {
-                this.detailItems.addAll(items);
-            }
+            addItems(this.detailItems, value);
         }
+    }
+    
+    private void addItems(List<CreateItem> list, TreeItem<CreateItemCollect> value) {
+        Optional.ofNullable(this.detailList.get(value.getValue())).ifPresent(list::addAll);
+        value.getChildren().forEach(child -> addItems(list, child));
     }
 
     /**

--- a/src/main/resources/logbook/gui/application.css
+++ b/src/main/resources/logbook/gui/application.css
@@ -14,3 +14,6 @@
 .titled-pane > .title {
     -fx-padding: 0.16665em 0.75em 0.16665em 0.75em; /* 2 9 2 9 */
 }
+.align_right {
+    -fx-alignment: center_right;
+}

--- a/src/main/resources/logbook/gui/createitemlog.fxml
+++ b/src/main/resources/logbook/gui/createitemlog.fxml
@@ -22,8 +22,8 @@
                   <TreeTableView fx:id="collect" VBox.vgrow="ALWAYS">
                      <columns>
                         <TreeTableColumn fx:id="unit" prefWidth="175.0" text="集計" />
-                        <TreeTableColumn fx:id="count" prefWidth="60.0" text="件数" />
-                        <TreeTableColumn fx:id="ratio" prefWidth="60.0" text="割合" />
+                        <TreeTableColumn fx:id="count" prefWidth="60.0" text="件数" styleClass="align_right"/>
+                        <TreeTableColumn fx:id="ratio" prefWidth="60.0" text="割合" styleClass="align_right" />
                      </columns>
                   </TreeTableView>
                   <ToolBar prefHeight="40.0" prefWidth="200.0">


### PR DESCRIPTION
#### 変更内容
開発ログには以下のような制限があった。
- ソート順は文字列順
- 件数の合計カウントはレシピのノードのみ
- レシピのノード以外を選択しても右の詳細表示はされない
- 左の集計ビューのカラム幅、ソート順は記録されない
- 右の表のソート順は記録されているが、選択を変えるとリセットされる

このPRはそれらの制限を取り除いた。結果的に新たな仕様は以下となる。
- ソート順は以下のように変更
  - アイテムのカテゴリ（「小口径主砲」など）ではデフォルトではID順、それ以外（昇順や降順）は文字列順
  - 件数カラム及び割合カラムでは数値でソート
  - それ以外（装備名、レシピ）は文字列でソート
- 件数の合計を装備、装備カテゴリまで合算するように変更
- 左のビューではどこを選択してもその条件に当てはまる開発ログを右のテーブルに表示
  - つまり「小口径主砲」をクリックするとすべての小口径主砲の開発ログが右に表示される
- 左のビューのカラム幅、ソート順を記録
- 右のビューのソート順は左の選択を変えても保持
- 件数、割合は右寄せで表示

#### 関連するIssue
Fixes #133
#165 の一部

