### PR TITLE
遠征ログの改善

### DIFF
--- a/src/main/java/logbook/internal/gui/MissionLogCollect.java
+++ b/src/main/java/logbook/internal/gui/MissionLogCollect.java
@@ -26,6 +26,9 @@ public class MissionLogCollect {
     /** 失敗 */
     private IntegerProperty fail;
 
+    /** ソート順 */
+    private int sortOrder;
+
     /** 集計単位 */
     @Getter
     @Setter
@@ -99,4 +102,21 @@ public class MissionLogCollect {
     public IntegerProperty failProperty() {
         return this.fail;
     }
+
+    /**
+     * ソート順を取得します。
+     * @return ソート順
+     */
+    public int getSortOrder() {
+        return this.sortOrder;
+    }
+
+    /**
+     * ソート順を設定します。
+     * @return ソート順
+     */
+    public void setSortOrder(int sortOrder) {
+        this.sortOrder = sortOrder;
+    }
+
 }

--- a/src/main/java/logbook/internal/gui/MissionLogController.java
+++ b/src/main/java/logbook/internal/gui/MissionLogController.java
@@ -1,6 +1,8 @@
 package logbook.internal.gui;
 
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -309,7 +311,12 @@ public class MissionLogController extends WindowController {
                 MissionAggregate agg = new MissionAggregate();
                 agg.setResource(entry.getKey());
                 agg.setCount(entry.getValue());
-                agg.setAverage(((double) entry.getValue()) / subLog.size());
+                double average = ((double) entry.getValue()) / subLog.size();
+                average = BigDecimal.valueOf(entry.getValue())
+                    .divide(BigDecimal.valueOf(subLog.size()), 2, RoundingMode.HALF_UP)
+                    .setScale(2)
+                    .doubleValue();
+                agg.setAverage(average);
 
                 // 資材別の合計を表示する
                 this.aggregates.add(agg);

--- a/src/main/java/logbook/internal/gui/MissionLogController.java
+++ b/src/main/java/logbook/internal/gui/MissionLogController.java
@@ -185,7 +185,7 @@ public class MissionLogController extends WindowController {
 
         // 詳細
         SortedList<MissionLogDetail> sortedList = new SortedList<>(this.details);
-        this.detail.setItems(this.details);
+        this.detail.setItems(sortedList);
         sortedList.comparatorProperty().bind(this.detail.comparatorProperty());
         this.detail.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
         this.detail.setOnKeyPressed(TableTool::defaultOnKeyPressedHandler);
@@ -204,7 +204,7 @@ public class MissionLogController extends WindowController {
 
         // 集計
         SortedList<MissionAggregate> sortedList2 = new SortedList<>(this.aggregates);
-        this.aggregate.setItems(this.aggregates);
+        this.aggregate.setItems(sortedList2);
         sortedList2.comparatorProperty().bind(this.aggregate.comparatorProperty());
         this.aggregate.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
         this.aggregate.setOnKeyPressed(TableTool::defaultOnKeyPressedHandler);

--- a/src/main/resources/logbook/gui/missionlog.fxml
+++ b/src/main/resources/logbook/gui/missionlog.fxml
@@ -20,9 +20,9 @@
                   <TreeTableView fx:id="collect" VBox.vgrow="ALWAYS">
                      <columns>
                         <TreeTableColumn fx:id="unit" prefWidth="145.0" text="集計" />
-                        <TreeTableColumn fx:id="successGood" prefWidth="45.0" text="大成功" />
-                        <TreeTableColumn fx:id="success" prefWidth="45.0" text="成功" />
-                        <TreeTableColumn fx:id="fail" prefWidth="45.0" text="失敗" />
+                        <TreeTableColumn fx:id="successGood" prefWidth="45.0" text="大成功" styleClass="align_right" />
+                        <TreeTableColumn fx:id="success" prefWidth="45.0" text="成功" styleClass="align_right" />
+                        <TreeTableColumn fx:id="fail" prefWidth="45.0" text="失敗" styleClass="align_right" />
                      </columns>
                   </TreeTableView>
                </children>
@@ -36,8 +36,8 @@
                               <TableView fx:id="aggregate">
                                  <columns>
                                     <TableColumn fx:id="resource" prefWidth="100.0" text="資材" />
-                                    <TableColumn fx:id="count" prefWidth="75.0" text="合計" />
-                                    <TableColumn fx:id="average" prefWidth="45.0" text="平均" />
+                                    <TableColumn fx:id="count" prefWidth="75.0" text="合計" styleClass="align_right" />
+                                    <TableColumn fx:id="average" prefWidth="45.0" text="平均" styleClass="align_right" />
                                  </columns>
                                  <contextMenu>
                                     <ContextMenu>
@@ -58,14 +58,14 @@
                               <TableColumn fx:id="date" prefWidth="150.0" text="日付" />
                               <TableColumn fx:id="name" prefWidth="110.0" text="遠征名" />
                               <TableColumn fx:id="result" prefWidth="55.0" text="結果" />
-                              <TableColumn fx:id="fuel" prefWidth="40.0" text="燃料" />
-                              <TableColumn fx:id="ammo" prefWidth="40.0" text="弾薬" />
-                              <TableColumn fx:id="metal" prefWidth="40.0" text="鋼材" />
-                              <TableColumn fx:id="bauxite" prefWidth="45.0" text="ボーキ" />
+                              <TableColumn fx:id="fuel" prefWidth="40.0" text="燃料" styleClass="align_right" />
+                              <TableColumn fx:id="ammo" prefWidth="40.0" text="弾薬" styleClass="align_right" />
+                              <TableColumn fx:id="metal" prefWidth="40.0" text="鋼材" styleClass="align_right" />
+                              <TableColumn fx:id="bauxite" prefWidth="45.0" text="ボーキ" styleClass="align_right" />
                               <TableColumn fx:id="item1name" prefWidth="100.0" text="アイテム1" />
-                              <TableColumn fx:id="item1count" prefWidth="40.0" text="個数1" />
+                              <TableColumn fx:id="item1count" prefWidth="40.0" text="個数1" styleClass="align_right" />
                               <TableColumn fx:id="item2name" prefWidth="100.0" text="アイテム2" />
-                              <TableColumn fx:id="item2count" prefWidth="40.0" text="個数2" />
+                              <TableColumn fx:id="item2count" prefWidth="40.0" text="個数2" styleClass="align_right" />
                            </columns>
                            <contextMenu>
                               <ContextMenu>


### PR DESCRIPTION
#### 問題解析
遠征ログの右側のテーブルについて、ソート順は記憶されていたがそのソート順ではソートされていなかった。原因はオリジナルの ObservableList を SortedList で wrap し bind もされていたが、単純に setItem() にはオリジナルの ObservableList を渡していたため。

#### 変更内容
- 上記問題の修正
- 数値のカラムを右寄せするスタイルを適用
- 平均を小数点2桁までで以下四捨五入するように変更
- 集計のツリービューのソートを変更
  - 集計カラムのトップレベルノードのソートは初期状態（デイリーから先月までの並び）の昇順・降順
  - 集計カラムの遠征ノードのソートはデフォルトが海域順（艦これの表示順）、昇順・降順は文字列順
  - 大成功、成功、失敗は数値のソート（変更なし）
- 集計のツリービューのカラム幅、ソート順を記憶

#### 関連するIssue
N/A
