### PR TITLE
編成記録ビューの改善

### DIFF
--- a/src/main/java/logbook/internal/gui/Deck.java
+++ b/src/main/java/logbook/internal/gui/Deck.java
@@ -19,6 +19,7 @@ import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
+import javafx.scene.control.ScrollPane;
 import javafx.scene.control.TextField;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Pane;
@@ -74,6 +75,9 @@ public class Deck extends WindowController {
     @FXML
     private TilePane fleets;
 
+    @FXML
+    private ScrollPane decksPane;
+    
     /** 選択している編成 */
     private ObjectProperty<AppDeck> currentDeck = new SimpleObjectProperty<>();
 
@@ -104,6 +108,17 @@ public class Deck extends WindowController {
         this.currentDeck.addListener(this::changeCurrent);
         // 名前が変更された時のリスナー
         this.deckName.textProperty().addListener((ov, o, n) -> this.modified.set(true));
+        this.fleetList.getSelectionModel().selectedIndexProperty().addListener((ob, o, n) -> {
+            if (n != null) {
+                double maxX = this.deck.getWidth()-this.decksPane.getViewportBounds().getWidth();
+                double targetX = this.fleets.getChildren().get(n.intValue()).getBoundsInParent().getMinX();
+                this.decksPane.setHvalue(Math.min(targetX/maxX, 1.0));
+                
+                double maxY = this.deck.getHeight()-this.decksPane.getViewportBounds().getHeight();
+                double targetY = this.fleets.getBoundsInParent().getMinY()+this.fleets.getChildren().get(n.intValue()).getBoundsInParent().getMinY();
+                this.decksPane.setVvalue(Math.min(targetY/maxY, 1.0));
+            }
+        });
     }
 
     @FXML

--- a/src/main/resources/logbook/gui/deck.fxml
+++ b/src/main/resources/logbook/gui/deck.fxml
@@ -21,8 +21,8 @@
               <items>
                 <Button mnemonicParsing="false" onAction="#addNewDeck" text="新しい編成" />
                   <Pane prefHeight="0.0" prefWidth="10.0" />
-                  <Button mnemonicParsing="false" onAction="#up" text="↑" />
-                  <Button mnemonicParsing="false" onAction="#down" text="↓" />
+                  <Button fx:id="deckUp" mnemonicParsing="false" onAction="#up" text="↑" disable="true" />
+                  <Button fx:id="deckDown" mnemonicParsing="false" onAction="#down" text="↓" disable="true" />
               </items>
             </ToolBar>
             <ListView fx:id="deckList" styleClass="deckList" VBox.vgrow="ALWAYS" />
@@ -39,7 +39,7 @@
                   <Button mnemonicParsing="false" onAction="#storeImage" text="画像ファイルとして保存" />
                   <Label text="編成テンプレート" />
                   <ComboBox fx:id="preFleetList" />
-                  <Button mnemonicParsing="false" onAction="#addPreFleet" text="追加" />
+                  <Button fx:id="addPreFleet" mnemonicParsing="false" onAction="#addPreFleet" text="追加" disable="true"/>
               </items>
             </ToolBar>
             <ScrollPane fx:id="decksPane" VBox.vgrow="ALWAYS">

--- a/src/main/resources/logbook/gui/deck.fxml
+++ b/src/main/resources/logbook/gui/deck.fxml
@@ -42,7 +42,7 @@
                   <Button mnemonicParsing="false" onAction="#addPreFleet" text="追加" />
               </items>
             </ToolBar>
-            <ScrollPane VBox.vgrow="ALWAYS">
+            <ScrollPane fx:id="decksPane" VBox.vgrow="ALWAYS">
                <content>
                   <VBox fx:id="deck" styleClass="deck">
                      <children>


### PR DESCRIPTION
#### 変更内容
- 艦隊リスト（左下）を選択したらその艦隊を表示するためスクロールするようにした
- 艦隊リストに艦隊を上下に並べ替えるボタンを配置
- 意味のないボタン（編成リストで最上位の編成を選んでいるときの↑ボタンなど）を disable するように変更

#### 関連するIssue
Fixes #145 

