### PR TITLE
遠征プログレスバーが濃い黄色になる時間を1分に変更 #134

### DIFF
--- a/src/main/java/logbook/internal/gui/MissionPane.java
+++ b/src/main/java/logbook/internal/gui/MissionPane.java
@@ -38,7 +38,7 @@ public class MissionPane extends AnchorPane {
     private final Duration stage2 = Duration.ofMinutes(10);
 
     /** 色変化3段階目 */
-    private final Duration stage3 = Duration.ofMinutes(5);
+    private final Duration stage3 = Duration.ofMinutes(1);
 
     @FXML
     private ProgressBar progress;


### PR DESCRIPTION
#### 変更内容
艦これの仕様上残り1分から遠征帰投可能なので、5分ではなく1分から濃い黄色に変わるように変更する。

#### 関連するIssue
Fixes #134 

