### PR TITLE
艦隊タブの色を設定可能にする

### DIFF
--- a/src/main/java/logbook/bean/AppConfig.java
+++ b/src/main/java/logbook/bean/AppConfig.java
@@ -72,6 +72,21 @@ public final class AppConfig implements Serializable {
     /** 艦隊タブにラベル単位のタブを追加 */
     private boolean labelTabs = true;
 
+    /** 艦隊タブの色（無傷） */
+    private String tabColorNoDamage;
+    /** 艦隊タブの色（健在） */
+    private String tabColorLessThanSlightDamage;
+    /** 艦隊タブの色（小破） */
+    private String tabColorSlightDamage;
+    /** 艦隊タブの色（中破） */
+    private String tabColorHalfDamage;
+    /** 艦隊タブの色（大破） */
+    private String tabColorBadlyDamage;
+    /** 艦隊タブの色（未遠征） */
+    private String tabColorNoMission;
+    /** 艦隊タブの色（要補給） */
+    private String tabColorNeedRefuel;
+    
     /** 音量 */
     private int soundLevel = 85;
 

--- a/src/main/java/logbook/internal/gui/ConfigController.java
+++ b/src/main/java/logbook/internal/gui/ConfigController.java
@@ -172,6 +172,28 @@ public class ConfigController extends WindowController {
     @FXML
     private CheckBox labelTabs;
 
+    /** 艦隊タブの色（無傷） */
+    @FXML
+    private TextField tabColorNoDamage;
+    /** 艦隊タブの色（健在） */
+    @FXML
+    private TextField tabColorLessThanSlightDamage;
+    /** 艦隊タブの色（小破） */
+    @FXML
+    private TextField tabColorSlightDamage;
+    /** 艦隊タブの色（中破） */
+    @FXML
+    private TextField tabColorHalfDamage;
+    /** 艦隊タブの色（大破） */
+    @FXML
+    private TextField tabColorBadlyDamage;
+    /** 艦隊タブの色（未遠征） */
+    @FXML
+    private TextField tabColorNoMission;
+    /** 艦隊タブの色（要補給） */
+    @FXML
+    private TextField tabColorNeedRefuel;
+    
     /** 最前面に表示する */
     @FXML
     private CheckBox onTop;
@@ -355,6 +377,13 @@ public class ConfigController extends WindowController {
         this.imageZoomRate.setText(Integer.toString(conf.getImageZoomRate()));
         this.deckTabs.setSelected(conf.isDeckTabs());
         this.labelTabs.setSelected(conf.isLabelTabs());
+        this.tabColorNoDamage.setText(conf.getTabColorNoDamage());
+        this.tabColorLessThanSlightDamage.setText(conf.getTabColorLessThanSlightDamage());
+        this.tabColorSlightDamage.setText(conf.getTabColorSlightDamage());
+        this.tabColorHalfDamage.setText(conf.getTabColorHalfDamage());
+        this.tabColorBadlyDamage.setText(conf.getTabColorBadlyDamage());
+        this.tabColorNoMission.setText(conf.getTabColorNoMission());
+        this.tabColorNeedRefuel.setText(conf.getTabColorNeedRefuel());
         this.onTop.setSelected(conf.isOnTop());
         this.checkDoit.setSelected(conf.isCheckDoit());
         this.checkUpdate.setSelected(conf.isCheckUpdate());
@@ -453,6 +482,11 @@ public class ConfigController extends WindowController {
         conf.setRemind(Math.max(this.toInt(this.remind.getText()), 10));
         conf.setSoundLevel(this.toInt(this.soundLevel.getText()));
         conf.setMaterialLogInterval(this.toInt(this.materialLogInterval.getText()));
+        conf.setOnTop(this.onTop.isSelected());
+        conf.setCheckDoit(this.checkDoit.isSelected());
+        conf.setCheckUpdate(this.checkUpdate.isSelected());
+        conf.setReportPath(this.reportDir.getText());
+        
         conf.setApplyBattle(this.applyBattle.isSelected());
         conf.setApplyResult(this.applyResult.isSelected());
         conf.setBattleLogExpires(this.toInt(this.battleLogExpires.getText()));
@@ -465,10 +499,14 @@ public class ConfigController extends WindowController {
         conf.setImageZoomRate(this.toInt(this.imageZoomRate.getText()));
         conf.setDeckTabs(this.deckTabs.isSelected());
         conf.setLabelTabs(this.labelTabs.isSelected());
-        conf.setOnTop(this.onTop.isSelected());
-        conf.setCheckDoit(this.checkDoit.isSelected());
-        conf.setCheckUpdate(this.checkUpdate.isSelected());
-        conf.setReportPath(this.reportDir.getText());
+        conf.setTabColorNoDamage(this.tabColorNoDamage.getText());
+        conf.setTabColorLessThanSlightDamage(this.tabColorLessThanSlightDamage.getText());
+        conf.setTabColorSlightDamage(this.tabColorSlightDamage.getText());
+        conf.setTabColorHalfDamage(this.tabColorHalfDamage.getText());
+        conf.setTabColorBadlyDamage(this.tabColorBadlyDamage.getText());
+        conf.setTabColorNoMission(this.tabColorNoMission.getText());
+        conf.setTabColorNeedRefuel(this.tabColorNeedRefuel.getText());
+        
         ShipImageCacheStrategy shipImageCacheStrategy = ShipImageCacheStrategy.ALL;
         if (this.shipImageCacheStrategyAll.isSelected())
             shipImageCacheStrategy = ShipImageCacheStrategy.ALL;
@@ -481,18 +519,20 @@ public class ConfigController extends WindowController {
         conf.setHideShipImageFromShipTablePane(this.hideShipImageFromShipTablePane.isSelected());
         conf.setHideItemImageFromShipTablePane(this.hideItemImageFromShipTablePane.isSelected());
         conf.setVisiblePoseImageOnFleetTab(this.visiblePoseImageOnFleetTab.isSelected());
+        
         conf.setConnectionClose(this.connectionClose.isSelected());
         conf.setListenPort(this.toInt(this.listenPort.getText()));
         conf.setAllowOnlyFromLocalhost(this.allowOnlyFromLocalhost.isSelected());
         conf.setUseProxy(this.useProxy.isSelected());
-        conf.setProxyPort(this.toInt(this.proxyPort.getText()));
         conf.setProxyHost(this.proxyHost.getText());
+        conf.setProxyPort(this.toInt(this.proxyPort.getText()));
+        conf.setStoreApiStart2(this.storeApiStart2.isSelected());
+        conf.setStoreApiStart2Dir(this.storeApiStart2Dir.getText());
+        
         conf.setFfmpegPath(this.ffmpegPath.getText());
         conf.setFfmpegArgs(this.ffmpegArgs.getText());
         conf.setFfmpegExt(this.ffmpegExt.getText());
         conf.setUsePlugin(this.usePlugin.isSelected());
-        conf.setStoreApiStart2(this.storeApiStart2.isSelected());
-        conf.setStoreApiStart2Dir(this.storeApiStart2Dir.getText());
 
         this.bouyomiChanStore();
 

--- a/src/main/java/logbook/internal/gui/MainController.java
+++ b/src/main/java/logbook/internal/gui/MainController.java
@@ -272,8 +272,8 @@ public class MainController extends WindowController {
                     Tab tab = new Tab(port.getName(), pane);
                     tab.setClosable(false);
                     tab.getStyleClass().removeIf(s -> !s.equals("tab"));
-                    Optional.ofNullable(pane.tabCssClass())
-                            .ifPresent(tab.getStyleClass()::add);
+                    Optional.ofNullable(pane.tabStyle())
+                            .ifPresent(tab::setStyle);
                     tabs.add(tab);
                 }
             } else {
@@ -292,8 +292,8 @@ public class MainController extends WindowController {
                         FleetTabPane pane = (FleetTabPane) tab.getContent();
                         pane.update(port);
                         tab.getStyleClass().removeIf(s -> !s.equals("tab"));
-                        Optional.ofNullable(pane.tabCssClass())
-                                .ifPresent(tab.getStyleClass()::add);
+                        Optional.ofNullable(pane.tabStyle())
+                                .ifPresent(tab::setStyle);
                     }
                 }
             }
@@ -304,8 +304,8 @@ public class MainController extends WindowController {
                     FleetTabPane pane = (FleetTabPane) node;
                     pane.update();
                     tab.getStyleClass().removeIf(s -> !s.equals("tab"));
-                    Optional.ofNullable(pane.tabCssClass())
-                            .ifPresent(tab.getStyleClass()::add);
+                    Optional.ofNullable(pane.tabStyle())
+                            .ifPresent(tab::setStyle);
                 }
             }
         }

--- a/src/main/resources/logbook/gui/config.fxml
+++ b/src/main/resources/logbook/gui/config.fxml
@@ -23,7 +23,7 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.text.TextFlow?>
 
-<VBox maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="530.0" prefWidth="500.0" styleClass="configWindow" xmlns="http://javafx.com/javafx/8.0.232-ea" xmlns:fx="http://javafx.com/fxml/1" fx:controller="logbook.internal.gui.ConfigController">
+<VBox maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="530.0" prefWidth="600.0" styleClass="configWindow" xmlns="http://javafx.com/javafx/8.0.232-ea" xmlns:fx="http://javafx.com/fxml/1" fx:controller="logbook.internal.gui.ConfigController">
    <children>
       <TabPane VBox.vgrow="ALWAYS">
          <tabs>
@@ -168,6 +168,42 @@
                               <Label text="(一部の一覧表示にのみ適用)" GridPane.columnIndex="2" GridPane.rowIndex="3" />
                               <CheckBox fx:id="deckTabs" mnemonicParsing="false" text="所有艦娘一覧に艦隊単位のタブを追加" GridPane.columnSpan="2147483647" GridPane.rowIndex="4" />
                               <CheckBox fx:id="labelTabs" mnemonicParsing="false" text="所有艦娘一覧にラベル単位のタブを追加" GridPane.columnSpan="2147483647" GridPane.rowIndex="5" />
+                           </children>
+                        </GridPane>
+                        <Label styleClass="bold" text="艦隊タブの色" />
+                        <GridPane hgap="3">
+                           <columnConstraints>
+                              <ColumnConstraints fillWidth="false" />
+                              <ColumnConstraints fillWidth="false" />
+                              <ColumnConstraints fillWidth="false" />
+                              <ColumnConstraints fillWidth="false" />
+                              <ColumnConstraints fillWidth="false" />
+                              <ColumnConstraints fillWidth="false" />
+                              <ColumnConstraints fillWidth="false" />
+                              <ColumnConstraints fillWidth="false" />
+                              <ColumnConstraints fillWidth="false" />
+                              <ColumnConstraints fillWidth="false" />
+                           </columnConstraints>
+                           <rowConstraints>
+                              <RowConstraints prefHeight="30.0" vgrow="SOMETIMES" />
+                              <RowConstraints prefHeight="30.0" vgrow="SOMETIMES" />
+                           </rowConstraints>
+                           <children>
+                              <Label text="無傷" GridPane.rowIndex="0" />
+                              <TextField fx:id="tabColorNoDamage" prefWidth="70.0" promptText="-" GridPane.columnIndex="1" GridPane.rowIndex="0" />
+                              <Label text="健在" GridPane.columnIndex="2" GridPane.rowIndex="0" />
+                              <TextField fx:id="tabColorLessThanSlightDamage" prefWidth="70.0" promptText="#D0EEFF" GridPane.columnIndex="3" GridPane.rowIndex="0" />
+                              <Label text="小破" GridPane.columnIndex="4" GridPane.rowIndex="0" />
+                              <TextField fx:id="tabColorSlightDamage" prefWidth="70.0" promptText="#FFEB5C" GridPane.columnIndex="5" GridPane.rowIndex="0" />
+                              <Label text="中破" GridPane.columnIndex="6" GridPane.rowIndex="0" />
+                              <TextField fx:id="tabColorHalfDamage" prefWidth="70.0" promptText="#FFBC5C" GridPane.columnIndex="7" GridPane.rowIndex="0" />
+                              <Label text="大破" GridPane.columnIndex="8" GridPane.rowIndex="0" />
+                              <TextField fx:id="tabColorBadlyDamage" prefWidth="70.0" promptText="#FF655C" GridPane.columnIndex="9" GridPane.rowIndex="0" />
+                              <Label text="未遠征" GridPane.columnIndex="0" GridPane.rowIndex="1" />
+                              <TextField fx:id="tabColorNoMission" prefWidth="70.0" promptText="#87CEFA" GridPane.columnIndex="1" GridPane.rowIndex="1" />
+                              <Label text="要補給" GridPane.columnIndex="2" GridPane.rowIndex="1" />
+                              <TextField fx:id="tabColorNeedRefuel" prefWidth="70.0" promptText="#FFF030" GridPane.columnIndex="3" GridPane.rowIndex="1" />
+                              <Label text="（色を変えない場合は「-」（ハイフン）を指定）" GridPane.columnSpan="6"  GridPane.columnIndex="4" GridPane.rowIndex="1" />
                            </children>
                         </GridPane>
                      </children>


### PR DESCRIPTION
#### 変更内容
艦隊タブの色のストラテジーを変更し、かつユーザーによる設定を可能にした。現状のタブの色は：
- 大破艦あり：赤
- 中破艦あり：オレンジ
- 未補給の艦がいる場合：黄色
- 第二艦隊以降で遠征や連合艦隊編成に含まれていない場合：青
の順番に評価され、上位の条件に適合した場合にその色が決まる。色が決まった場合は左上から右下にかけてグラデーションでタブの色を変えている。

これを以下のように変更する。まず以下の順に評価し、
- 大破艦あり：赤
- 中破艦あり：オレンジ
- 小破艦あり：黄色
- 小破未満のダメージ艦あり：水色
- 全艦無傷：なし
タブの左上の色を決定する。次に
- 未補給の艦がいる：黄色
- 第二艦隊以降で遠征や連合艦隊編成に含まれていない：青
によってタブの右下の色を決定する。それぞれの色が決定したらその色に従って左上から右下にかけてグラデーションで表現する。どちらかの色がない場合は背景色、両方の色がない場合は色なしのタブになる。

また、これらの色の設定を設定可能にした。ただデフォルトの挙動は従来と近いものにするため、指定しない（空欄）場合はおおむね上のような色設定になるようにしている。なので指定なし（その条件でも色を変えない）にしたい場合はハイフン（`-`)を受け付けることにした。設定画面にもそのような注釈をつけている。

ついでにタブに色がついたときにタブの縁取りがなくなっていたのも修正した。

![image](https://user-images.githubusercontent.com/3181895/87220602-2fa8d980-c3a0-11ea-8477-0353b2b25086.png)


#### 関連するIssue
Fixes  #136

