### PR TITLE
演習詳細を出せるようにする #73

### DIFF
--- a/src/main/java/logbook/api/ApiReqPracticeBattle.java
+++ b/src/main/java/logbook/api/ApiReqPracticeBattle.java
@@ -1,0 +1,44 @@
+package logbook.api;
+
+import java.util.Optional;
+
+import javax.json.JsonObject;
+
+import logbook.bean.AppCondition;
+import logbook.bean.BattleLog;
+import logbook.bean.BattleTypes.IFormation;
+import logbook.bean.SortieBattle;
+import logbook.proxy.RequestMetaData;
+import logbook.proxy.ResponseMetaData;
+
+/**
+ * /kcsapi/api_req_practice/battle
+ *
+ */
+@API("/kcsapi/api_req_practice/battle")
+public class ApiReqPracticeBattle implements APIListenerSpi {
+
+    @Override
+    public void accept(JsonObject json, RequestMetaData req, ResponseMetaData res) {
+        try {
+            JsonObject data = json.getJsonObject("api_data");
+            if (data != null) {
+                AppCondition condition = AppCondition.get();
+                BattleLog log = new BattleLog();
+                condition.setPracticeBattleResult(log);
+                if (log != null) {
+                    log.setBattle(SortieBattle.toBattle(data));
+                    // 出撃艦隊
+                    Integer dockId = Optional.ofNullable(log.getBattle())
+                            .map(IFormation::getDockId)
+                            .orElse(1);
+                    // 艦隊スナップショットを作る
+                    BattleLog.snapshot(log, dockId);
+                }
+            }
+        } catch (Throwable e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/src/main/java/logbook/api/ApiReqPracticeBattleresult.java
+++ b/src/main/java/logbook/api/ApiReqPracticeBattleresult.java
@@ -1,0 +1,44 @@
+package logbook.api;
+
+import java.util.Optional;
+
+import javax.json.JsonObject;
+
+import logbook.bean.AppCondition;
+import logbook.bean.BattleLog;
+import logbook.bean.BattleResult;
+import logbook.bean.BattleTypes.IFormation;
+import logbook.internal.Logs;
+import logbook.proxy.RequestMetaData;
+import logbook.proxy.ResponseMetaData;
+
+/**
+ * /kcsapi/api_req_practice/battle_result
+ *
+ */
+@API("/kcsapi/api_req_practice/battle_result")
+public class ApiReqPracticeBattleresult implements APIListenerSpi {
+
+    @Override
+    public void accept(JsonObject json, RequestMetaData req, ResponseMetaData res) {
+        try {
+            JsonObject data = json.getJsonObject("api_data");
+            if (data != null) {
+                BattleResult result = BattleResult.toBattleResult(data);
+                BattleLog log = AppCondition.get().getPracticeBattleResult();
+                if (log != null) {
+                    log.setResult(result);
+                    log.setTime(Logs.nowString());
+                    // 出撃艦隊
+                    Integer dockId = Optional.ofNullable(log.getBattle())
+                            .map(IFormation::getDockId)
+                            .orElse(1);
+                    // 艦隊スナップショットを作る
+                    BattleLog.snapshot(log, dockId);
+                }
+            }
+        } catch (Throwable e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/logbook/api/ApiReqPracticeMidnightBattle.java
+++ b/src/main/java/logbook/api/ApiReqPracticeMidnightBattle.java
@@ -1,0 +1,30 @@
+package logbook.api;
+
+import javax.json.JsonObject;
+
+import logbook.bean.AppCondition;
+import logbook.bean.BattleLog;
+import logbook.bean.BattleMidnightBattle;
+import logbook.proxy.RequestMetaData;
+import logbook.proxy.ResponseMetaData;
+
+/**
+ * /kcsapi/api_req_practice/midnight_battle
+ *
+ */
+@API("/kcsapi/api_req_practice/midnight_battle")
+public class ApiReqPracticeMidnightBattle implements APIListenerSpi {
+
+    @Override
+    public void accept(JsonObject json, RequestMetaData req, ResponseMetaData res) {
+        JsonObject data = json.getJsonObject("api_data");
+        if (data != null) {
+
+            BattleLog log = AppCondition.get().getPracticeBattleResult();
+            if (log != null) {
+                log.setMidnight(BattleMidnightBattle.toBattle(data));
+            }
+        }
+    }
+
+}

--- a/src/main/java/logbook/bean/AppCondition.java
+++ b/src/main/java/logbook/bean/AppCondition.java
@@ -36,6 +36,9 @@ public class AppCondition implements Serializable {
     /** 最後の戦闘結果 */
     private BattleLog battleResultConfirm;
 
+    /** 演習結果 */
+    private BattleLog practiceBattleResult;
+
     /** 退避艦ID */
     private Set<Integer> escape = new HashSet<>();
 

--- a/src/main/java/logbook/internal/Ships.java
+++ b/src/main/java/logbook/internal/Ships.java
@@ -44,6 +44,9 @@ import lombok.Data;
  */
 public class Ships {
 
+    /** 敵艦IDの下限(inclusive) */
+    public static final int MIN_ENEMY_ID = 1500;
+
     /** 小破(75%) */
     public static final double SLIGHT_DAMAGE = 0.75D;
     /** 中破(50%) */
@@ -834,7 +837,8 @@ public class Ships {
             return Messages.getString("ship.name", shipMst(chara)
                     .map(mst -> {
                         String yomi = mst.getYomi();
-                        if (yomi == null || "-".equals(yomi) || yomi.isEmpty()) {
+                        // 敵艦として1500未満のIDが出てくるのは演習のみ（もっといい判別の仕方があれば差し替えたほうが良いかも）
+                        if (yomi == null || "-".equals(yomi) || yomi.isEmpty() || mst.getId() < MIN_ENEMY_ID) {
                             return mst.getName();
                         } else {
                             return mst.getName() + yomi;

--- a/src/main/java/logbook/internal/gui/BattleDetail.java
+++ b/src/main/java/logbook/internal/gui/BattleDetail.java
@@ -21,6 +21,7 @@ import javafx.scene.control.Control;
 import javafx.scene.control.Label;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
+import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 import javafx.stage.WindowEvent;
 import logbook.bean.BattleLog;
@@ -97,6 +98,10 @@ public class BattleDetail extends WindowController {
     /** フェーズ */
     @FXML
     private VBox phase;
+
+    /** ルート情報 */
+    @FXML
+    private HBox routeInfo;
 
     /** マス */
     @FXML
@@ -190,7 +195,7 @@ public class BattleDetail extends WindowController {
             this.log = log;
         }
         if (this.log != null) {
-            MapStartNext last = this.log.getNext().get(this.log.getNext().size() - 1);
+            MapStartNext last = this.log.getNext().size() > 0 ? this.log.getNext().get(this.log.getNext().size() - 1) : null;
             CombinedType combinedType = this.log.getCombinedType();
             Map<Integer, List<Ship>> deckMap = this.log.getDeckMap();
             Map<Integer, SlotItem> itemMap = this.log.getItemMap();
@@ -268,19 +273,24 @@ public class BattleDetail extends WindowController {
         PhaseState ps = new PhaseState(this.combinedType, this.battle, this.deckMap, this.itemMap, this.escape);
 
         // マス
-        boolean boss = this.last.getNo().equals(this.last.getBosscellNo()) || this.last.getEventId() == 5;
-        this.mapcell.setText(this.last.getMapareaId()
-                + "-" + this.last.getMapinfoNo()
-                + "-" + Mapping.getCell(this.last.getMapareaId(), this.last.getMapinfoNo(), this.last.getNo())
-                + (boss ? "(ボス)" : ""));
-        // ルート
-        if (this.routeList != null) {
-            this.route.setText(this.routeList.stream()
-                    .map(Mapping::getCell)
-                    .collect(Collectors.joining("→"))
-                    + Optional.ofNullable(this.battleCount).map(v -> "(戦闘" + v + "回)").orElse(""));
+        if (this.last != null) {
+            boolean boss = this.last.getNo().equals(this.last.getBosscellNo()) || this.last.getEventId() == 5;
+            this.mapcell.setText(this.last.getMapareaId()
+                    + "-" + this.last.getMapinfoNo()
+                    + "-" + Mapping.getCell(this.last.getMapareaId(), this.last.getMapinfoNo(), this.last.getNo())
+                    + (boss ? "(ボス)" : ""));
+            // ルート
+            if (this.routeList != null) {
+                this.route.setText(this.routeList.stream()
+                        .map(Mapping::getCell)
+                        .collect(Collectors.joining("→"))
+                        + Optional.ofNullable(this.battleCount).map(v -> "(戦闘" + v + "回)").orElse(""));
+            } else {
+                this.route.setText("");
+            }
         } else {
-            this.route.setText("");
+            this.routeInfo.getChildren().clear();
+            this.routeInfo.getChildren().add(new Label("演習詳細"));
         }
 
         // 艦隊行動

--- a/src/main/java/logbook/internal/gui/MainMenuController.java
+++ b/src/main/java/logbook/internal/gui/MainMenuController.java
@@ -115,7 +115,31 @@ public class MainMenuController extends WindowController {
                             ((BattleDetail) c).setData(sendlog);
                         }, null);
             } else {
-                Tools.Conrtols.alert(AlertType.INFORMATION, "現在の戦闘", "戦闘中ではありません", this.parentController.getWindow());
+                Tools.Conrtols.alert(AlertType.INFORMATION, "現在の戦闘", "戦闘のデータがありません", this.parentController.getWindow());
+            }
+        } catch (Exception ex) {
+            LoggerHolder.get().error("詳細の表示に失敗しました", ex);
+        }
+    }
+
+    /**
+     * 現在の演習
+     * 
+     * @param e ActionEvent
+     */
+    @FXML
+    void practiceStatus(ActionEvent e) {
+        try {
+            BattleLog log = AppCondition.get().getPracticeBattleResult();
+            if (log != null && log.getBattle() != null) {
+                BattleLog sendlog = log;
+                InternalFXMLLoader.showWindow("logbook/gui/battle_detail.fxml", this.parentController.getWindow(),
+                        "演習詳細", c -> {
+                            ((BattleDetail) c).setInterval(() -> AppCondition.get().getPracticeBattleResult());
+                            ((BattleDetail) c).setData(sendlog);
+                        }, null);
+            } else {
+                Tools.Conrtols.alert(AlertType.INFORMATION, "演習詳細", "演習のデータがありません", this.parentController.getWindow());
             }
         } catch (Exception ex) {
             LoggerHolder.get().error("詳細の表示に失敗しました", ex);

--- a/src/main/resources/META-INF/services/logbook.api.APIListenerSpi
+++ b/src/main/resources/META-INF/services/logbook.api.APIListenerSpi
@@ -52,6 +52,9 @@ logbook.api.ApiReqMissionResult
 logbook.api.ApiReqMissionStart
 logbook.api.ApiReqNyukyoSpeedchange
 logbook.api.ApiReqNyukyoStart
+logbook.api.ApiReqPracticeBattle
+logbook.api.ApiReqPracticeBattleresult
+logbook.api.ApiReqPracticeMidnightBattle
 logbook.api.ApiReqQuestClearitemget
 logbook.api.ApiReqQuestStop
 logbook.api.ApiReqSortieAirbattle

--- a/src/main/resources/logbook/gui/battle_detail.fxml
+++ b/src/main/resources/logbook/gui/battle_detail.fxml
@@ -25,7 +25,7 @@
                         <Insets top="3.0" />
                      </HBox.margin>
                      <children>
-                        <HBox>
+                        <HBox fx:id="routeInfo">
                            <children>
                               <Label style="-fx-padding: 0 3px 0 0;" text="マス:" />
                               <Label fx:id="mapcell" styleClass="bold" />

--- a/src/main/resources/logbook/gui/main_menu.fxml
+++ b/src/main/resources/logbook/gui/main_menu.fxml
@@ -13,6 +13,7 @@
             <MenuItem mnemonicParsing="false" onAction="#capture" text="キャプチャ" />
             <SeparatorMenuItem mnemonicParsing="false" />
             <MenuItem mnemonicParsing="false" onAction="#battleStatus" text="現在の戦闘" />
+            <MenuItem mnemonicParsing="false" onAction="#practiceStatus" text="現在の演習" />
             <MenuItem mnemonicParsing="false" onAction="#battlelog" text="戦闘ログ">
                    <accelerator>
                       <KeyCodeCombination alt="UP" code="A" control="DOWN" meta="UP" shift="UP" shortcut="UP" />


### PR DESCRIPTION
#### 変更内容
これまで「現在の戦闘」で詳細が確認できていたのは通常の戦闘のみで、演習については確認できていなかった。データとしては通常の戦闘と同様なのでルート情報等演習にない項目を除けばそれほど修正量は多くないので、まずこのPRでは直近の演習のデータを通常の戦闘とは別に `AppCondition` に保持し、それを表示する別メニューを実装した。ただし通常の戦闘とは異なり戦闘ログ（CSV）も戦闘詳細（JSON）も保存されていないので、このPRではあくまでも直近の演習のデータのみの対応となっている。

CSVや詳細についてはこの後 #92 の対応等で実装を行うかもしれないが、とりあえず現時点では直近の演習のみの対応とする。

#### 関連するIssue
Fixes #73

