### PR TITLE
トーストの表示位置を設定可能にする #97

### DIFF
--- a/src/main/java/logbook/bean/AppConfig.java
+++ b/src/main/java/logbook/bean/AppConfig.java
@@ -42,6 +42,9 @@ public final class AppConfig implements Serializable {
     /** 通知でトーストを表示 */
     private boolean useToast = true;
 
+    /** トーストの位置 (default: BOTTOM_RIGHT) */
+    private String toastLocation;
+
     /** 遠征完了時のリマインド */
     private boolean useRemind = true;
 

--- a/src/main/java/logbook/internal/gui/Tools.java
+++ b/src/main/java/logbook/internal/gui/Tools.java
@@ -236,12 +236,26 @@ public class Tools {
          * @param hide 消えるまでの秒数
          */
         public static void showNotify(Node node, String title, String message, Duration hide) {
+            showNotify(node, title, message, hide, 
+                    Optional.ofNullable(AppConfig.get().getToastLocation()).map(Pos::valueOf).orElse(Pos.BOTTOM_RIGHT));
+        }
+
+        /**
+         * 通知を表示する
+         *
+         * @param node グラフィック
+         * @param title タイトル
+         * @param message メッセージ
+         * @param hide 消えるまでの秒数
+         * @param pos 出す位置
+         */
+        public static void showNotify(Node node, String title, String message, Duration hide, Pos position) {
             Notifications notifications = Notifications.create()
                     .graphic(node)
                     .title(title)
                     .text(message)
                     .hideAfter(hide)
-                    .position(Pos.BOTTOM_RIGHT);
+                    .position(position);
             if (node == null) {
                 notifications.showInformation();
             } else {

--- a/src/main/resources/logbook/gui/config.fxml
+++ b/src/main/resources/logbook/gui/config.fxml
@@ -41,7 +41,7 @@
                           <rowConstraints>
                               <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
                               <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                            <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                            <RowConstraints minHeight="10.0" prefHeight="24.0" vgrow="SOMETIMES" />
                               <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
                               <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
                               <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
@@ -79,14 +79,18 @@
                                     <RadioButton fx:id="fontSizeLarge2" mnemonicParsing="false" text="大きい" toggleGroup="$fontSize" />
                                  </children>
                               </HBox>
-                              <CheckBox fx:id="useNotification" mnemonicParsing="false" text="遠征・入渠完了時に通知をする" GridPane.columnSpan="2147483647" GridPane.rowIndex="2" />
+                              <HBox  alignment="CENTER_LEFT" GridPane.rowIndex="2" GridPane.columnSpan="2147483647">
+                                 <CheckBox fx:id="useNotification" mnemonicParsing="false" text="遠征・入渠完了時に通知をする" />
+                                 <CheckBox fx:id="useToast" mnemonicParsing="false" text="通知でトーストを表示" />
+                              </HBox>
                               <CheckBox fx:id="alertBadlyStart" mnemonicParsing="false" text="出撃時に大破艦がいる場合に通知をする" GridPane.columnSpan="2147483647" GridPane.rowIndex="3" />
                               <CheckBox fx:id="alertBadlyNext" mnemonicParsing="false" text="進撃時に大破艦がいる場合に通知をする" GridPane.columnSpan="2147483647" GridPane.rowIndex="4" />
                               <CheckBox fx:id="useSound" mnemonicParsing="false" text="通知でサウンドを鳴らす" GridPane.columnSpan="2147483647" GridPane.rowIndex="5" />
                               <Label text="デフォルトサウンド" GridPane.rowIndex="6" />
                               <TextField fx:id="defaultNotifySound" prefWidth="200.0" GridPane.columnIndex="1" GridPane.rowIndex="6" />
                               <Button mnemonicParsing="false" onAction="#selectSoundFile" text="参照..." GridPane.columnIndex="2" GridPane.rowIndex="6" />
-                              <CheckBox fx:id="useToast" mnemonicParsing="false" text="通知でトーストを表示" GridPane.columnSpan="2147483647" GridPane.rowIndex="7" />
+                              <Label text="トーストの位置" GridPane.rowIndex="7" />
+                              <ChoiceBox fx:id="toastLocation" prefWidth="60.0" GridPane.columnIndex="1"  GridPane.rowIndex="7" />
                               <CheckBox fx:id="useRemind" mnemonicParsing="false" text="遠征完了時のリマインド(秒)" GridPane.rowIndex="8" />
                               <TextField fx:id="remind" prefWidth="60.0" GridPane.columnIndex="1" GridPane.rowIndex="8" />
                               <Label text="音量(%)" GridPane.rowIndex="9" />


### PR DESCRIPTION
#### 変更内容
ギミック達成等で表示されるトーストの表示位置を変更できるようにした。変更内容は：
- 設定画面に「トーストの位置」という新たな項目を設置し、「左上」「左下」「右上」「右下」から選べるようにした
- デフォルトの表示位置はこれまで同様の位置である「右下」とした
- 設定を変更したらお試しのトーストを表示するようにした

![image](https://user-images.githubusercontent.com/3181895/87286659-16389680-c534-11ea-9ab8-dc283e270cc1.png)

また、コードを調査してたら、設定で「通知でトーストを表示」の設定が有効なのは遠征・入渠の通知のみだったので、その設定は遠征・入渠用だとわかるように位置を遠征・入渠用の項目の右に移動し、その空いた行に新たな設定を配置した。

#### 関連するIssue
Fixes #97 
