### PR TITLE
演習詳細で相手艦の中破以上をダメージ絵で表示し、かつ撃破した相手艦を撃沈表示にしない

### DIFF
--- a/src/main/java/logbook/api/ApiReqPracticeBattle.java
+++ b/src/main/java/logbook/api/ApiReqPracticeBattle.java
@@ -26,15 +26,14 @@ public class ApiReqPracticeBattle implements APIListenerSpi {
                 AppCondition condition = AppCondition.get();
                 BattleLog log = new BattleLog();
                 condition.setPracticeBattleResult(log);
-                if (log != null) {
-                    log.setBattle(SortieBattle.toBattle(data));
-                    // 出撃艦隊
-                    Integer dockId = Optional.ofNullable(log.getBattle())
-                            .map(IFormation::getDockId)
-                            .orElse(1);
-                    // 艦隊スナップショットを作る
-                    BattleLog.snapshot(log, dockId);
-                }
+                log.setPractice(true);
+                log.setBattle(SortieBattle.toBattle(data));
+                // 出撃艦隊
+                Integer dockId = Optional.ofNullable(log.getBattle())
+                        .map(IFormation::getDockId)
+                        .orElse(1);
+                // 艦隊スナップショットを作る
+                BattleLog.snapshot(log, dockId);
             }
         } catch (Throwable e) {
             e.printStackTrace();

--- a/src/main/java/logbook/bean/BattleLog.java
+++ b/src/main/java/logbook/bean/BattleLog.java
@@ -68,6 +68,9 @@ public class BattleLog implements Serializable {
     /** ローデータ */
     private RawData raw;
 
+    /** 演習かどうか */
+    private boolean isPractice;
+
     /**
      * 艦隊スナップショットを作成します
      * @param log 戦闘ログ

--- a/src/main/java/logbook/bean/Chara.java
+++ b/src/main/java/logbook/bean/Chara.java
@@ -111,4 +111,12 @@ public interface Chara extends Cloneable {
         throw new IllegalStateException(this + " is not an Enemy");
     }
 
+    /**
+     * このオブジェクトが演習相手である場合 true を返します。
+     * @return このオブジェクトが演習相手である場合 true
+     */
+    @JsonIgnore
+    default boolean isPractice() {
+        return false;
+    }
 }

--- a/src/main/java/logbook/bean/Enemy.java
+++ b/src/main/java/logbook/bean/Enemy.java
@@ -32,6 +32,9 @@ public class Enemy implements Chara, Serializable, Cloneable {
     /** 序列 */
     private Integer order;
 
+    /** 演習相手かどうか */
+    private boolean practice;
+
     @Override
     public boolean isEnemy() {
         return true;

--- a/src/main/java/logbook/internal/ShipImage.java
+++ b/src/main/java/logbook/internal/ShipImage.java
@@ -248,7 +248,7 @@ class ShipImage {
                 } else if (Ships.isHalfDamage(chara)) {
                     layers.add(HALF_DAMAGE_BADGE);
                     layers.add(HALF_DAMAGE_BACKGROUND);
-                } else if (Ships.isBadlyDamage(chara)) {
+                } else if (Ships.isBadlyDamage(chara) || (Ships.isLost(chara) && chara.isPractice())) {
                     layers.add(BADLY_DAMAGE_BADGE);
                     layers.add(BADLY_DAMAGE_BACKGROUND);
                 } else if (Ships.isLost(chara)) {
@@ -497,7 +497,7 @@ class ShipImage {
         if (mst.isPresent()) {
             Path dir = ShipMst.getResourcePathDir(mst.get());
             String[] names;
-            if ((chara.isShip() || chara.isFriend())
+            if ((chara.isShip() || chara.isFriend() || chara.isPractice())
                     && (Ships.isHalfDamage(chara) || Ships.isBadlyDamage(chara) || Ships.isLost(chara))) {
                 names = damaged;
             } else {

--- a/src/main/java/logbook/internal/Ships.java
+++ b/src/main/java/logbook/internal/Ships.java
@@ -44,9 +44,6 @@ import lombok.Data;
  */
 public class Ships {
 
-    /** 敵艦IDの下限(inclusive) */
-    public static final int MIN_ENEMY_ID = 1500;
-
     /** 小破(75%) */
     public static final double SLIGHT_DAMAGE = 0.75D;
     /** 中破(50%) */
@@ -837,8 +834,7 @@ public class Ships {
             return Messages.getString("ship.name", shipMst(chara)
                     .map(mst -> {
                         String yomi = mst.getYomi();
-                        // 敵艦として1500未満のIDが出てくるのは演習のみ（もっといい判別の仕方があれば差し替えたほうが良いかも）
-                        if (yomi == null || "-".equals(yomi) || yomi.isEmpty() || mst.getId() < MIN_ENEMY_ID) {
+                        if (yomi == null || "-".equals(yomi) || yomi.isEmpty() || chara.isPractice()) {
                             return mst.getName();
                         } else {
                             return mst.getName() + yomi;

--- a/src/main/java/logbook/internal/gui/BattleDetail.java
+++ b/src/main/java/logbook/internal/gui/BattleDetail.java
@@ -167,6 +167,9 @@ public class BattleDetail extends WindowController {
     @FXML
     private Label exp;
 
+    /** 演習かどうか */
+    private boolean isPractice;
+
     /** 周期タイマー */
     private Timeline timeline = new Timeline();
 
@@ -205,7 +208,8 @@ public class BattleDetail extends WindowController {
             BattleResult result = this.log.getResult();
             Integer battleCount = this.log.getBattleCount();
             List<String> route = this.log.getRoute();
-            this.setData(last, combinedType, deckMap, escape, itemMap, battle, midnight, result, battleCount, route);
+            boolean isPractice = this.log.isPractice();
+            this.setData(last, combinedType, deckMap, escape, itemMap, battle, midnight, result, battleCount, route, isPractice);
         }
     }
 
@@ -221,10 +225,11 @@ public class BattleDetail extends WindowController {
      * @param result 戦果報告 
      * @param battleCount 戦闘回数
      * @param route ルート
+     * @param isPractice 演習かどうか
      */
     void setData(MapStartNext last, CombinedType combinedType, Map<Integer, List<Ship>> deckMap, Set<Integer> escape,
             Map<Integer, SlotItem> itemMap, IFormation battle, IMidnightBattle midnight, BattleResult result,
-            Integer battleCount, List<String> route) {
+            Integer battleCount, List<String> route, boolean isPractice) {
         int hashCode = Objects.hash(last, battle, midnight, result);
         if (this.hashCode == hashCode) {
             return;
@@ -241,6 +246,7 @@ public class BattleDetail extends WindowController {
         this.result = result;
         this.battleCount = battleCount;
         this.routeList = route;
+        this.isPractice = isPractice;
         this.update();
     }
 
@@ -271,7 +277,9 @@ public class BattleDetail extends WindowController {
 
     private void setInfo() {
         PhaseState ps = new PhaseState(this.combinedType, this.battle, this.deckMap, this.itemMap, this.escape);
-
+        if (this.isPractice) {
+            ps.getAfterEnemy().forEach(enemy -> enemy.setPractice(true));
+        }
         // マス
         if (this.last != null) {
             boolean boss = this.last.getNo().equals(this.last.getBosscellNo()) || this.last.getEventId() == 5;
@@ -399,6 +407,9 @@ public class BattleDetail extends WindowController {
      */
     private void setPhase() {
         PhaseState ps = new PhaseState(this.combinedType, this.battle, this.deckMap, this.itemMap, this.escape);
+        if (this.isPractice) {
+            ps.getAfterEnemy().forEach(enemy -> enemy.setPractice(true));
+        }
 
         // 評価初期化
         Judge judge = new Judge();


### PR DESCRIPTION
#### 変更内容
#187 にて演習においても戦闘詳細と同等の情報を表示するようにしたが、演習相手の情報が敵艦と同様に扱われていたため、以下のような挙動になっていた。
- 中破以上してもダメージ絵にならない
- HPが0いかになると撃沈表示となり轟沈したかのように見える
この挙動を実際の演習と合わせるため、中破絵の表示および大破どまりにするように変更した。ただHP1残しと撃破が区別できないと困るので、数値での表記は1にせずに0やマイナス表示のままとする。

![image](https://user-images.githubusercontent.com/3181895/87326437-ad6e1000-c56d-11ea-9121-891a42dbbbe0.png)

#### 関連するIssue
N/A

