### PR TITLE
受諾中でない任務も表示する #141

### DIFF
--- a/src/main/java/logbook/bean/AppQuest.java
+++ b/src/main/java/logbook/bean/AppQuest.java
@@ -43,6 +43,9 @@ public class AppQuest implements Serializable {
     /** 期限 */
     private String expire;
 
+    /** 受諾中 */
+    private boolean active;
+
     /**
      * 任務を構築します
      *
@@ -53,6 +56,7 @@ public class AppQuest implements Serializable {
         AppQuest bean = new AppQuest();
         bean.setNo(quest.getNo());
         bean.setQuest(quest);
+        bean.setActive(quest.getState() == 2 || quest.getState() == 3);  // 受諾中、もしくは完了済み
 
         ZonedDateTime base = ZonedDateTime.now(ZoneId.of("GMT+04:00"))
                 .truncatedTo(ChronoUnit.DAYS);

--- a/src/main/java/logbook/bean/AppQuestCollection.java
+++ b/src/main/java/logbook/bean/AppQuestCollection.java
@@ -57,15 +57,14 @@ public class AppQuestCollection implements Serializable {
     public void update(QuestList questList) {
         this.update();
 
-        val copyMap = new ConcurrentSkipListMap<>(this.quest);
+        // 今はすべての Quest が一度に送られてくるので、既にある map を保持しておく必要はない
+        ConcurrentSkipListMap<Integer, AppQuest> copyMap = new ConcurrentSkipListMap<>();
         if (questList.getList() != null) {
             for (Quest quest : questList.getList()) {
                 if (quest != null) {
-                    copyMap.remove(quest.getNo());
-
+                    AppQuest appQuest = AppQuest.toAppQuest(quest);
+                    copyMap.put(quest.getNo(), appQuest);
                     if (quest.getState() == 2) {
-                        AppQuest appQuest = AppQuest.toAppQuest(quest);
-                        copyMap.put(quest.getNo(), appQuest);
                         AppQuestDuration.get().set(appQuest);
                     } else {
                         AppQuestDuration.get().unset(quest.getNo());

--- a/src/main/java/logbook/internal/gui/MainController.java
+++ b/src/main/java/logbook/internal/gui/MainController.java
@@ -4,6 +4,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.MessageFormat;
 import java.time.Duration;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -395,6 +396,8 @@ public class MainController extends WindowController {
             quest.clear();
             questMap.values()
                     .stream()
+                    // 受諾中の任務を上に持ってくる
+                    .sorted(Comparator.comparing(AppQuest::isActive).reversed())
                     .map(QuestPane::new)
                     .forEach(quest::add);
             // ハッシュ・コードの更新

--- a/src/main/java/logbook/internal/gui/QuestPane.java
+++ b/src/main/java/logbook/internal/gui/QuestPane.java
@@ -103,7 +103,9 @@ public class QuestPane extends HBox {
             default:
                 break;
             }
-
+            if (!this.quest.isActive()) {
+                this.getStyleClass().add("inactive");
+            }
             switch (quest.getProgressFlag()) {
             case 1:
                 this.progress.setStartAngle(90);
@@ -118,8 +120,13 @@ public class QuestPane extends HBox {
                 this.progress.setLength(360 * 0.8);
                 break;
             default:
-                this.progress.setRadiusX(2);
-                this.progress.setRadiusY(2);
+                if (quest.getState() == 3) {
+                    this.progress.setRadiusX(5);
+                    this.progress.setRadiusY(5);
+                } else {
+                    this.progress.setRadiusX(2);
+                    this.progress.setRadiusY(2);
+                }
                 this.progress.setLength(360);
                 break;
             }

--- a/src/main/resources/logbook/gui/main.css
+++ b/src/main/resources/logbook/gui/main.css
@@ -231,6 +231,9 @@ TabPane .tab.empty .tab-label {
 .quest.kaisou .progress {
     -fx-fill: #7058a3;
 }
+.quest.inactive {
+    -fx-opacity: 0.3;
+}
 
 .fully {
     -fx-base: #FFD700;


### PR DESCRIPTION
#### 変更内容
任務の進捗をチェックするときなど、受諾中以外の任務が見れたほうがよい場合がある。これに対応するため受諾中でない任務も薄くして表示するようにした。

![image](https://user-images.githubusercontent.com/3181895/87439101-53cc1b00-c62b-11ea-97a7-a79ab46147c2.png)

主にチェックしたいのは受諾中の任務だと思うので、ソート順は変わらずID順だが、受諾中の任務を上位に持ってくるようなソート順にしている。

また、昔は任務を開いたときにその開かれているページにある任務の情報のみが送られてきていたため、これまでに取得した任務の情報を保持しておく必要があったが、任務にフィルター（カテゴリごとの絞り込み）が実装されたとき以降は任務を開いたときにすべての任務情報が送られてくるように変更された。その対応コードも同時に実装しておく。

#### 関連するIssue
Fixes #141

