### PR TITLE
無傷時に大破時の色を使っていたバグを修正 #192

### DIFF
--- a/src/main/java/logbook/internal/gui/FleetTabPane.java
+++ b/src/main/java/logbook/internal/gui/FleetTabPane.java
@@ -333,7 +333,7 @@ public class FleetTabPane extends ScrollPane {
             left = Optional.ofNullable(conf.getTabColorLessThanSlightDamage()).map(String::trim).filter(color -> color.length() > 0).orElse("#D0EEFF");
         } else {
             // 無傷時
-            left = Optional.ofNullable(conf.getTabColorBadlyDamage()).map(String::trim).filter(color -> color.length() > 0).orElse(null);
+            left = Optional.ofNullable(conf.getTabColorNoDamage()).map(String::trim).filter(color -> color.length() > 0).orElse(null);
         }
         if (this.shipList.stream()
                 .anyMatch(ship -> !ship.getFuel().equals(Ships.shipMst(ship).map(ShipMst::getFuelMax).orElse(0)) ||


### PR DESCRIPTION
#### 問題解析
https://github.com/sanaehirotaka/logbook-kai/issues/192#issuecomment-658583746 でご指摘のあったとおり、本来無傷用の設定を参照すべきところで誤って大破用の設定を参照していたことによる。

#### 変更内容
`getTabColorNoDamage()` を呼ぶように修正。

#### 関連するIssue
Fixes #192 

