### PR TITLE
任務でAllのタブの場合にのみデータを更新する #194

### DIFF
--- a/src/main/java/logbook/api/ApiGetMemberQuestlist.java
+++ b/src/main/java/logbook/api/ApiGetMemberQuestlist.java
@@ -21,7 +21,7 @@ public class ApiGetMemberQuestlist implements APIListenerSpi {
             QuestList quest = QuestList.toQuestList(data);
 
             AppQuestCollection.get()
-                    .update(quest);
+                    .update(quest, "0".equals(req.getParameter("api_tab_id")));
         }
     }
 

--- a/src/main/java/logbook/bean/AppQuestCollection.java
+++ b/src/main/java/logbook/bean/AppQuestCollection.java
@@ -54,11 +54,11 @@ public class AppQuestCollection implements Serializable {
      *
      * @param questList 任務
      */
-    public void update(QuestList questList) {
+    public void update(QuestList questList, boolean all) {
         this.update();
 
-        // 今はすべての Quest が一度に送られてくるので、既にある map を保持しておく必要はない
-        ConcurrentSkipListMap<Integer, AppQuest> copyMap = new ConcurrentSkipListMap<>();
+        // 今はすべての Quest が一度に送られてくるので、all のタブのデータの場合は既にある map を保持しておく必要はない
+        ConcurrentSkipListMap<Integer, AppQuest> copyMap  = all ? new ConcurrentSkipListMap<>() : new ConcurrentSkipListMap<>(this.quest);
         if (questList.getList() != null) {
             for (Quest quest : questList.getList()) {
                 if (quest != null) {


### PR DESCRIPTION
#### 問題解析
`20.7.5` で受諾していない任務を表示する変更を入れたが、同時に今の任務のAPIは全てのページのデータが送られて来るため常にリストを置き換えるように変更したところ、 #194 の報告にあるような不具合が発生した。原因は任務画面の縦のタブ（左側にあるデイリー等で絞り込むタブ）をクリックした時にも任務APIが呼ばれ、その場合はそのタブに属する任務の情報しか送られてこないため。横のタブ（上側にあるカテゴリで絞り込むタブ）のほうは任務APIは呼ばれないため問題の不具合は生じない。

#### 変更内容
どのタブをクリックした時に呼ばれた任務APIなのかはリクエストからわかるので、tab index が0、つまりAllの時のみリストの置き換えとし、それ以外の場合は以前のようにデータが来た任務についてのみ更新するように変更した。技術的には恐らくAllのときのみ対応すればいいはずだが、将来任務APIの仕様が変わってAllのタブが0以外になったりする場合なども考慮し、上記のような実装を採用した。（ちなみに置き換えを採用している理由は、以前の実装だと過去に一度でも受けたワンオフ任務などをlogbook-kaiを通さずにクリアしてしまうと削除を押すまで永遠に残り続けてしまうため。）

#### 関連するIssue
Fixes #194 

