### PR TITLE
遠征条件の修正および遠征条件ビューの改善

### DIFF
--- a/src/main/java/logbook/bean/MissionCondition.java
+++ b/src/main/java/logbook/bean/MissionCondition.java
@@ -17,7 +17,7 @@ import logbook.internal.Ships;
 import lombok.Data;
 
 @Data
-public class MissionCondition implements Predicate<List<Ship>> {
+public class MissionCondition implements TestAllPredicate<List<Ship>> {
 
     @JsonProperty("description")
     private String description;
@@ -292,5 +292,6 @@ public class MissionCondition implements Predicate<List<Ship>> {
             sb.append("(" + this.description + ")");
         }
         return sb.toString();
-    }
+    }    
+    
 }

--- a/src/main/java/logbook/bean/TestAllPredicate.java
+++ b/src/main/java/logbook/bean/TestAllPredicate.java
@@ -1,0 +1,26 @@
+package logbook.bean;
+
+import java.util.Objects;
+import java.util.function.Predicate;
+
+public interface TestAllPredicate<T> extends Predicate<T> {
+    @Override
+    default public TestAllPredicate<T> and(Predicate<? super T> other) {
+        Objects.requireNonNull(other);
+        return (t) -> {
+            boolean result1 = test(t);
+            boolean result2 = other.test(t);
+            return result1 && result2;
+        };
+    }
+
+    @Override
+    default public TestAllPredicate<T> or(Predicate<? super T> other) {
+        Objects.requireNonNull(other);
+        return (t) -> {
+            boolean result1 = test(t);
+            boolean result2 = other.test(t);
+            return result1 || result2;
+        };
+    }
+}

--- a/src/main/resources/logbook/mission/1/A4.json
+++ b/src/main/resources/logbook/mission/1/A4.json
@@ -19,8 +19,18 @@
                         {"type": "艦娘", "ship_type" :["軽巡洋艦"]},
                         {"type": "艦娘", "ship_type" :["駆逐艦"]},
                         {"type": "艦娘", "ship_type" :["駆逐艦"]},
+                        {"type": "艦娘"},
+                        {"type": "艦娘"}
+                    ]
+                },
+                {
+                    "operator": "AND",
+                    "conditions": [
                         {"type": "艦娘", "ship_type" :["駆逐艦"]},
-                        {"type": "艦娘", "ship_type" :["駆逐艦"]}
+                        {"type": "艦娘", "ship_type" :["海防艦"]},
+                        {"type": "艦娘", "ship_type" :["海防艦"]},
+                        {"type": "艦娘", "ship_type" :["海防艦"]},
+                        {"type": "艦娘"}
                     ]
                 },
                 {
@@ -29,8 +39,28 @@
                         {"type": "艦娘", "ship_type" :["護衛空母"]},
                         {"type": "艦娘", "ship_type" :["駆逐艦"]},
                         {"type": "艦娘", "ship_type" :["駆逐艦"]},
-                        {"type": "艦娘", "ship_type" :["駆逐艦"]},
-                        {"type": "艦娘", "ship_type" :["駆逐艦"]}
+                        {"type": "艦娘"},
+                        {"type": "艦娘"}
+                    ]
+                },
+                {
+                    "operator": "AND",
+                    "conditions": [
+                        {"type": "艦娘", "ship_type" :["護衛空母"]},
+                        {"type": "艦娘", "ship_type" :["海防艦"]},
+                        {"type": "艦娘", "ship_type" :["海防艦"]},
+                        {"type": "艦娘"},
+                        {"type": "艦娘"}
+                    ]
+                },
+                {
+                    "operator": "AND",
+                    "conditions": [
+                        {"type": "艦娘", "ship_type" :["軽巡洋艦", "練習巡洋艦"]},
+                        {"type": "艦娘", "ship_type" :["海防艦"]},
+                        {"type": "艦娘", "ship_type" :["海防艦"]},
+                        {"type": "艦娘"},
+                        {"type": "艦娘"}
                     ]
                 }
             ]


### PR DESCRIPTION
#### 問題解析
A4の遠征条件が現状判明している条件と異なっている。

#### 変更内容
A4の遠征条件の定義ファイルを更新。

関連して、遠征条件の評価の logical operator （and/or）は `Predicate` で実装されているが、and 条件なら片方の条件が false の時点で、or 条件なら true の時点で探索を終了してしまうため、結果としてもう片方の条件が評価されない。そうなると遠征条件ビューにおいては最初に満たしていない条件が出てきた時点でそれ以降の条件を満たしているかどうかがわからず、「？」で表示されてしまう。それを解決するため、評価を行う際には operator の双方の値の評価を行ってから戻り値を計算するように変更した。

![image](https://user-images.githubusercontent.com/3181895/87776374-a4798900-c862-11ea-8fbc-31eea7908f0b.png)

（従来バージョンだと火力条件を満たしていない時点で、対空以降の条件はすべて「？」で表示される。）

#### 関連するIssue
#197 (一部)

