### PR TITLE
各種ビューで任意の（整数値の）パラメータでフィルターできるようにする

### DIFF
--- a/src/main/java/logbook/bean/AppItemTableConfig.java
+++ b/src/main/java/logbook/bean/AppItemTableConfig.java
@@ -1,0 +1,52 @@
+package logbook.bean;
+
+import logbook.internal.Config;
+import lombok.Data;
+
+/**
+ * 所有装備一覧の設定
+ *
+ */
+@Data
+public class AppItemTableConfig {
+
+    /** インデックス */
+    private int tabIndex;
+
+    /** 装備タブの設定 */
+    private ItemTabConfig itemTabConfig;
+    
+    /** 基地航空隊タブの設定 */
+    private AirbaseTabConfig airbaseTabConfig;
+    
+    /**
+     * 装備タブの設定
+     */
+    @Data
+    public static class ItemTabConfig {
+        private boolean filterExpanded;
+        private boolean textFilterEnabled;
+        private String textFilter;
+    }
+
+    /**
+     * 基地航空隊タブの設定
+     */
+    @Data
+    public static class AirbaseTabConfig {
+        private boolean filterExpanded;
+    }
+
+    /**
+     * アプリケーションのデフォルト設定ディレクトリから<code>AppItemTableConfig</code>を取得します、
+     * これは次の記述と同等です
+     * <blockquote>
+     *     <code>Config.getDefault().get(AppItemTableConfig.class, AppItemTableConfig::new)</code>
+     * </blockquote>
+     *
+     * @return <code>AppShipTableConfig</code>
+     */
+    public static AppItemTableConfig get() {
+        return Config.getDefault().get(AppItemTableConfig.class, AppItemTableConfig::new);
+    }
+}

--- a/src/main/java/logbook/bean/AppItemTableConfig.java
+++ b/src/main/java/logbook/bean/AppItemTableConfig.java
@@ -1,5 +1,7 @@
 package logbook.bean;
 
+import java.util.List;
+
 import logbook.internal.Config;
 import lombok.Data;
 
@@ -34,7 +36,11 @@ public class AppItemTableConfig {
      */
     @Data
     public static class AirbaseTabConfig {
+        /** フィルターが展開されていたかどうか */
         private boolean filterExpanded;
+
+        /** パラメータフィルター */
+        private List<ParameterFilterConfig> parameterFilters;
     }
 
     /**

--- a/src/main/java/logbook/bean/AppItemTableConfig.java
+++ b/src/main/java/logbook/bean/AppItemTableConfig.java
@@ -26,9 +26,18 @@ public class AppItemTableConfig {
      */
     @Data
     public static class ItemTabConfig {
+        /** フィルターが展開されていたかどうか */
         private boolean filterExpanded;
+
+        /** テキストフィルターがオンだったかどうか */
         private boolean textFilterEnabled;
+
+        /** テキストフィルター */
         private String textFilter;
+
+        /** パラメータフィルター */
+        private List<ParameterFilterConfig> parameterFilters;
+
     }
 
     /**

--- a/src/main/java/logbook/bean/AppShipTableConfig.java
+++ b/src/main/java/logbook/bean/AppShipTableConfig.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.Map;
 
 import logbook.internal.Config;
-import logbook.internal.Operator;
 import lombok.Data;
 
 /**
@@ -40,23 +39,8 @@ public class AppShipTableConfig {
         /** 艦種 */
         private List<String> typeValue;
 
-        /** コンディション */
-        private boolean conditionEnabled;
-
-        /** コンディション */
-        private String conditionValue;
-
-        /** コンディション条件 */
-        private Operator conditionType;
-
-        /** レベル */
-        private boolean levelEnabled;
-
-        /** レベル */
-        private String levelValue;
-
-        /** レベル条件 */
-        private Operator levelType;
+        /** パラメータフィルター */
+        private List<ParameterFilterConfig> parameterFilters;
 
         /** ラベル条件 */
         private boolean labelEnabled;

--- a/src/main/java/logbook/bean/ParameterFilterConfig.java
+++ b/src/main/java/logbook/bean/ParameterFilterConfig.java
@@ -1,0 +1,21 @@
+package logbook.bean;
+
+import logbook.internal.Operator;
+import lombok.Data;
+
+/**
+ * パラメータフィルターの設定
+ */
+@Data
+public class ParameterFilterConfig {
+    /** 有効 */
+    private boolean enabled;
+    /** 選ばれていたパラメータ */
+    private String name;
+    /** フィールドの値 */
+    private Integer value;
+    /** 選択のインデックス */
+    private Integer valueChoice;
+    /** 比較タイプ */
+    private Operator type;
+}

--- a/src/main/java/logbook/internal/ComparableFilter.java
+++ b/src/main/java/logbook/internal/ComparableFilter.java
@@ -1,0 +1,30 @@
+package logbook.internal;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import lombok.Builder;
+
+@Builder
+/**
+ * 任意の <code>Comparable</code> なパラメータによるフィルター
+ *
+ * @param <S> 比較するパラメータを持っているクラス
+ * @param <T> 比較するパラメータの型
+ */
+public class ComparableFilter<S, T extends Comparable<T>> implements Predicate<S> {
+    /** ShipItem からパラメータに変換する mapper */
+    private Function<S, T> mapper;
+    /** 比較対象の値 */
+    private T value;
+    /** 演算子 */
+    private Operator type;
+
+    @Override
+    public boolean test(S obj) {
+        if (obj == null) {
+            return false;
+        }
+        return this.type.compare(this.mapper.apply(obj), this.value);
+    }
+}

--- a/src/main/java/logbook/internal/gui/ItemAirBaseController.java
+++ b/src/main/java/logbook/internal/gui/ItemAirBaseController.java
@@ -25,11 +25,13 @@ import javafx.scene.control.SpinnerValueFactory.IntegerSpinnerValueFactory;
 import javafx.scene.control.TableCell;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
+import javafx.scene.control.TitledPane;
 import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.StackPane;
 import logbook.Messages;
+import logbook.bean.AppItemTableConfig;
 import logbook.bean.SlotItemCollection;
 import logbook.bean.SlotitemMst;
 import logbook.bean.SlotitemMstCollection;
@@ -46,6 +48,8 @@ import lombok.val;
 public class ItemAirBaseController extends WindowController {
 
     // フィルター
+    @FXML
+    private TitledPane filter;
 
     @FXML
     private ToggleSwitch seikuFilter;
@@ -177,7 +181,8 @@ public class ItemAirBaseController extends WindowController {
     void initialize() {
         try {
             TableTool.setVisible(this.itemTable, this.getClass().toString() + "#" + "airBaseItemTable");
-
+            
+            this.filter.expandedProperty().addListener((ob, o, n) -> saveConfig());
             // フィルター 初期値
             this.seikuType.setItems(FXCollections.observableArrayList(Operator.values()));
             this.seikuType.getSelectionModel().select(Operator.GE);
@@ -289,7 +294,8 @@ public class ItemAirBaseController extends WindowController {
             SortedList<AirBaseItem> sortedAirBaseItems = new SortedList<>(this.items);
             this.itemTable.setItems(sortedAirBaseItems);
             sortedAirBaseItems.comparatorProperty().bind(this.itemTable.comparatorProperty());
-
+            
+            loadConfig();
         } catch (Exception e) {
             LoggerHolder.get().error("FXMLの初期化に失敗しました", e);
         }
@@ -469,7 +475,19 @@ public class ItemAirBaseController extends WindowController {
             LoggerHolder.get().error("FXMLの初期化に失敗しました", e);
         }
     }
+    
+    private void loadConfig() {
+        Optional.ofNullable(AppItemTableConfig.get()).map(AppItemTableConfig::getAirbaseTabConfig).ifPresent((config) -> {
+            this.filter.setExpanded(config.isFilterExpanded());
+        });
+    }
 
+    private void saveConfig() {
+        AppItemTableConfig config = AppItemTableConfig.get();
+        AppItemTableConfig.AirbaseTabConfig airbaseTabConfig = new AppItemTableConfig.AirbaseTabConfig();
+        airbaseTabConfig.setFilterExpanded(this.filter.isExpanded());
+        config.setAirbaseTabConfig(airbaseTabConfig);
+    }
     /**
      * フィルター
      *

--- a/src/main/java/logbook/internal/gui/ItemAirBaseController.java
+++ b/src/main/java/logbook/internal/gui/ItemAirBaseController.java
@@ -376,10 +376,7 @@ public class ItemAirBaseController extends WindowController {
                         .get(itemId);
 
                 if (mst != null) {
-                    ImageView img = new ImageView(Items.itemImage(mst));
-                    img.setFitWidth(36);
-                    img.setFitHeight(36);
-                    this.setGraphic(img);
+                    this.setGraphic(Tools.Conrtols.zoomImage(new ImageView(Items.itemImage(mst))));
                     this.setText(mst.getName());
                 }
             } else {

--- a/src/main/java/logbook/internal/gui/ItemController.java
+++ b/src/main/java/logbook/internal/gui/ItemController.java
@@ -1,19 +1,29 @@
 package logbook.internal.gui;
 
 import javafx.fxml.FXML;
+import javafx.scene.control.TabPane;
 import javafx.stage.Stage;
+import logbook.bean.AppItemTableConfig;
 
 /**
  * 所有装備一覧のUIコントローラー(親)
  *
  */
 public class ItemController extends WindowController {
-
+    @FXML
+    private TabPane tab;
+    
     @FXML
     private ItemItemController itemController;
 
     @FXML
     private ItemAirBaseController airbaseController;
+
+    @FXML
+    void initialize() {
+        this.tab.getSelectionModel().select(AppItemTableConfig.get().getTabIndex());
+        this.tab.getSelectionModel().selectedIndexProperty().addListener((ob, o, n) -> AppItemTableConfig.get().setTabIndex(n.intValue()));
+    }
 
     @Override
     public void setWindow(Stage window) {

--- a/src/main/java/logbook/internal/gui/ItemItemController.java
+++ b/src/main/java/logbook/internal/gui/ItemItemController.java
@@ -305,10 +305,7 @@ public class ItemItemController extends WindowController {
                         .get(itemId);
 
                 if (mst != null) {
-                    ImageView img = new ImageView(Items.itemImage(mst));
-                    img.setFitWidth(36);
-                    img.setFitHeight(36);
-                    this.setGraphic(img);
+                    this.setGraphic(Tools.Conrtols.zoomImage(new ImageView(Items.itemImage(mst))));
                     this.setText(mst.getName());
                 }
             } else {

--- a/src/main/java/logbook/internal/gui/ParameterFilterPane.java
+++ b/src/main/java/logbook/internal/gui/ParameterFilterPane.java
@@ -1,0 +1,237 @@
+package logbook.internal.gui;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.controlsfx.control.ToggleSwitch;
+
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.ReadOnlyObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.value.ObservableValue;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.control.ChoiceBox;
+import javafx.scene.control.Spinner;
+import javafx.scene.control.SpinnerValueFactory.IntegerSpinnerValueFactory;
+import javafx.scene.layout.GridPane;
+import logbook.bean.ParameterFilterConfig;
+import logbook.internal.ComparableFilter;
+import logbook.internal.LoggerHolder;
+import logbook.internal.Operator;
+import logbook.internal.Ships;
+import logbook.internal.ToStringConverter;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+abstract class ParameterFilterPane<T> extends GridPane {
+    @Data
+    @AllArgsConstructor
+    @RequiredArgsConstructor
+    static final class IntegerParameter<T> {
+        private final String name;
+        private final Function<T, Integer> mapper;
+        private final Supplier<IntegerSpinnerValueFactory> valueFactory;
+        private Supplier<IntStream> values;
+        private Function<Integer, String> labelMapper;
+    }
+
+    /** パラメータフィルタのオンオフ */
+    @FXML
+    private ChoiceBox<IntegerParameter<T>> parameter;
+
+    /** パラメータ */
+    @FXML
+    private ToggleSwitch parameterFilter;
+
+    /** パラメータ値 */
+    @FXML
+    private Spinner<Integer> parameterValue;
+
+    /** パラメータ値 */
+    @FXML
+    private ChoiceBox<Integer> parameterValueChoice;
+
+    /** パラメータ条件 */
+    @FXML
+    private ChoiceBox<Operator> parameterType;
+
+    /** フィルター */
+    private final ObjectProperty<Predicate<T>> filter = new SimpleObjectProperty<>();
+
+    /** パラメータのリスト */
+    private final List<IntegerParameter<T>> items;
+
+    protected ParameterFilterPane(List<IntegerParameter<T>> items) {
+        this.items = items;
+        try {
+            FXMLLoader loader = InternalFXMLLoader.load("logbook/gui/param_filter_pane.fxml");
+            loader.setRoot(this);
+            loader.setController(this);
+            loader.load();
+        } catch (IOException e) {
+            LoggerHolder.get().error("FXMLのロードに失敗しました", e);
+        }
+    }
+
+    public ReadOnlyObjectProperty<Predicate<T>> filterProperty() {
+        return this.filter;
+    }
+
+    @FXML
+    void initialize() {
+        this.parameterType.setItems(FXCollections.observableArrayList(Operator.values()));
+        this.parameterType.getSelectionModel().select(Operator.GE);
+        this.parameter.setConverter(ToStringConverter.of(IntegerParameter::getName));
+        this.parameter.setItems(FXCollections.observableArrayList(this.items));
+        this.parameter.getSelectionModel().selectedItemProperty().addListener((ob, o, n) -> {
+            if (n != null) {
+                if (n.getLabelMapper() != null) {
+                    ObservableList<Integer> items = FXCollections.observableArrayList(n.getValues().get().mapToObj(Integer::valueOf).collect(Collectors.toList()));
+                    this.parameterValueChoice.setItems(items);
+                    this.parameterValueChoice.setConverter(ToStringConverter.of(n.getLabelMapper()));
+                    this.parameterValueChoice.setVisible(true);
+                    this.parameterValue.setVisible(false);
+                    this.parameterValueChoice.getSelectionModel().select(0);
+                } else {
+                    String text = this.parameterValue.getEditor().getText();
+                    this.parameterValue.setValueFactory(n.getValueFactory().get());
+                    if (text != null) {
+                        try {
+                            Integer.parseInt(text);
+                            this.parameterValue.getEditor().setText(text);  // ちゃんと数字だったときのみセットする
+                        } catch (Throwable e) {
+                            // ignore
+                        }
+                    }
+                    this.parameterValueChoice.setVisible(false);
+                    this.parameterValue.setVisible(true);
+                }
+            }
+        });
+        this.parameter.getSelectionModel().select(0);
+        this.parameterFilter.selectedProperty().addListener((ob, ov, nv) -> {
+            this.parameter.setDisable(!nv);
+            this.parameterValue.setDisable(!nv);
+            this.parameterType.setDisable(!nv);
+        });
+        this.parameterValue.setEditable(true);
+        this.parameterFilter.selectedProperty().addListener(this::filterAction);
+        this.parameter.getSelectionModel().selectedItemProperty().addListener(this::filterAction);
+        this.parameterValue.valueProperty().addListener(this::filterAction);
+        this.parameterValue.getEditor().textProperty().addListener(this::filterAction);
+        this.parameterValueChoice.getSelectionModel().selectedItemProperty().addListener(this::filterAction);
+        this.parameterType.getSelectionModel().selectedItemProperty().addListener(this::filterAction);
+    }
+    
+    /**
+     * フィルターを設定するアクション
+     */
+    private void filterAction(ObservableValue<?> observable, Object oldValue, Object newValue) {
+        this.filter.set(this.createFilter());
+    }
+
+    /**
+     * フィルターを作る
+     * @return フィルター
+     */
+    private Predicate<T> createFilter() {
+        if (this.parameterFilter.isSelected()) {
+            Integer value = null;
+            if (this.parameterValue.isVisible()) {
+                try {
+                    value = Integer.parseInt(this.parameterValue.getEditor().getText());
+                } catch (Throwable e) {
+                    value = this.parameterValue.getValue(); // just in case
+                }
+            } else {
+                value = this.parameterValueChoice.getValue();
+            }
+            ComparableFilter.ComparableFilterBuilder<T, Integer> b = ComparableFilter.builder();
+            return b.mapper(this.parameter.getValue().getMapper()).value(Optional.ofNullable(value).orElse(0)).type( this.parameterType.getValue()).build();
+        }
+        return null;
+    }
+
+    /**
+     * 設定をロードする
+     * @param parameterFilterConfig 設定
+     */
+    public void loadConfig(ParameterFilterConfig parameterFilterConfig) {
+        this.parameterFilter.setSelected(parameterFilterConfig.isEnabled());
+        Optional.ofNullable(parameterFilterConfig.getName())
+            .flatMap(p -> this.items.stream().filter((ip) -> ip.getName().equals(p)).findAny())
+            .ifPresent(this.parameter::setValue);
+        if (this.parameterValue.getValueFactory() != null) {
+            Optional.ofNullable(parameterFilterConfig.getValue()).ifPresent(this.parameterValue.getValueFactory()::setValue);
+        }
+        Optional.ofNullable(parameterFilterConfig.getValueChoice()).ifPresent(this.parameterValueChoice.getSelectionModel()::select);
+    }
+    
+    /**
+     * 設定を保存するためのオブジェクトを作成
+     * @return 設定保存用のオブジェクト
+     */
+    public ParameterFilterConfig saveConfig() {
+        ParameterFilterConfig config = new ParameterFilterConfig();
+        config.setEnabled(this.parameterFilter.isSelected());
+        Optional.ofNullable(this.parameter.getValue()).map(IntegerParameter::getName).ifPresent(config::setName);
+        Integer value = null;
+        try {
+            value = Integer.parseInt(this.parameterValue.getEditor().getText());
+        } catch (Throwable e) {
+            value = this.parameterValue.getValue(); // just in case
+        }
+        Optional.ofNullable(value).ifPresent(config::setValue);
+        Optional.ofNullable(this.parameterValueChoice.getValue()).ifPresent(config::setValueChoice);
+        return config;
+    }
+
+    /**
+     * 艦娘のパラメータ用のペイン
+     */
+    static class ShipItemParameterFilterPane extends ParameterFilterPane<ShipItem> {
+        
+        private static final List<IntegerParameter<ShipItem>> SHIPITEM_PARAMETERS;
+        
+        static {
+            SHIPITEM_PARAMETERS = Stream.of(
+                    new IntegerParameter<ShipItem>("cond", ShipItem::getCond, () -> new IntegerSpinnerValueFactory(0, 100, 53)),
+                    new IntegerParameter<ShipItem>("Lv", ShipItem::getLv, () -> new IntegerSpinnerValueFactory(1, 175, 99)),
+                    new IntegerParameter<ShipItem>("ID", ShipItem::getId, () -> new IntegerSpinnerValueFactory(1, Integer.MAX_VALUE)),
+                    new IntegerParameter<ShipItem>("exp", ShipItem::getExp, () -> new IntegerSpinnerValueFactory(0, Integer.MAX_VALUE)),
+                    new IntegerParameter<ShipItem>("next", ShipItem::getNext, () -> new IntegerSpinnerValueFactory(0, Integer.MAX_VALUE)),
+                    new IntegerParameter<ShipItem>("制空", ShipItem::getSeiku, () -> new IntegerSpinnerValueFactory(0, Integer.MAX_VALUE)),
+                    new IntegerParameter<ShipItem>("砲戦火力", ShipItem::getHPower, () -> new IntegerSpinnerValueFactory(0, Integer.MAX_VALUE)),
+                    new IntegerParameter<ShipItem>("雷戦火力", ShipItem::getRPower, () -> new IntegerSpinnerValueFactory(0, Integer.MAX_VALUE)),
+                    new IntegerParameter<ShipItem>("夜戦火力", ShipItem::getYPower, () -> new IntegerSpinnerValueFactory(0, Integer.MAX_VALUE)),
+                    new IntegerParameter<ShipItem>("対潜火力", ShipItem::getTPower, () -> new IntegerSpinnerValueFactory(0, Integer.MAX_VALUE)),
+                    new IntegerParameter<ShipItem>("火力(素)", ShipItem::getKaryoku, () -> new IntegerSpinnerValueFactory(0, Integer.MAX_VALUE)),
+                    new IntegerParameter<ShipItem>("雷装(素)", ShipItem::getRaisou, () -> new IntegerSpinnerValueFactory(0, Integer.MAX_VALUE)),
+                    new IntegerParameter<ShipItem>("対空(素)", ShipItem::getTaiku, () -> new IntegerSpinnerValueFactory(0, Integer.MAX_VALUE)),
+                    new IntegerParameter<ShipItem>("対潜(素)", ShipItem::getTais, () -> new IntegerSpinnerValueFactory(0, Integer.MAX_VALUE)),
+                    new IntegerParameter<ShipItem>("索敵(素)", ShipItem::getSakuteki, () -> new IntegerSpinnerValueFactory(0, Integer.MAX_VALUE)),
+                    new IntegerParameter<ShipItem>("運(素)", ShipItem::getLucky, () -> new IntegerSpinnerValueFactory(0, Integer.MAX_VALUE)),
+                    new IntegerParameter<ShipItem>("耐久", ShipItem::getMaxhp, () -> new IntegerSpinnerValueFactory(1, Integer.MAX_VALUE)),
+                    new IntegerParameter<ShipItem>("装甲(素)", ShipItem::getSoukou, () -> new IntegerSpinnerValueFactory(0, Integer.MAX_VALUE)),
+                    new IntegerParameter<ShipItem>("回避(素)", ShipItem::getKaihi, () -> new IntegerSpinnerValueFactory(0, Integer.MAX_VALUE)),
+                    new IntegerParameter<ShipItem>("速力", ShipItem::getSoku, null, () -> IntStream.of(5, 10, 15, 20), Ships::sokuText),
+                    new IntegerParameter<ShipItem>("射程", ShipItem::getLeng, null, () -> IntStream.range(1, 5), Ships::lengText)
+            ).collect(Collectors.toList());
+        }
+
+        ShipItemParameterFilterPane() {
+            super(SHIPITEM_PARAMETERS);
+        }
+    }
+}

--- a/src/main/java/logbook/internal/gui/ParameterFilterPane.java
+++ b/src/main/java/logbook/internal/gui/ParameterFilterPane.java
@@ -234,7 +234,36 @@ abstract class ParameterFilterPane<T> extends GridPane {
             super(SHIPITEM_PARAMETERS);
         }
     }
-    
+
+    /**
+     * 装備一覧のパラメータ用のペイン
+     */
+    static class ItemParameterFilterPane extends ParameterFilterPane<Item> {
+        
+        private static final List<IntegerParameter<Item>> ITEM_PARAMETERS;
+        
+        static {
+            ITEM_PARAMETERS = Stream.of(
+                    new IntegerParameter<Item>("所持", Item::getCount, () -> new IntegerSpinnerValueFactory(1, Integer.MAX_VALUE, 1)),
+                    new IntegerParameter<Item>("火力", Item::getHoug, () -> new IntegerSpinnerValueFactory(0, Integer.MAX_VALUE, 0)),
+                    new IntegerParameter<Item>("命中", Item::getHoum, () -> new IntegerSpinnerValueFactory(0, Integer.MAX_VALUE, 0)),
+                    new IntegerParameter<Item>("射程", Item::getLeng, () -> new IntegerSpinnerValueFactory(0, Integer.MAX_VALUE, 0)),
+                    new IntegerParameter<Item>("運", Item::getLuck, () -> new IntegerSpinnerValueFactory(0, Integer.MAX_VALUE, 0)),
+                    new IntegerParameter<Item>("回避", Item::getHouk, () -> new IntegerSpinnerValueFactory(0, Integer.MAX_VALUE, 0)),
+                    new IntegerParameter<Item>("爆装", Item::getBaku, () -> new IntegerSpinnerValueFactory(0, Integer.MAX_VALUE, 0)),
+                    new IntegerParameter<Item>("雷装", Item::getRaig, () -> new IntegerSpinnerValueFactory(0, Integer.MAX_VALUE, 0)),
+                    new IntegerParameter<Item>("索敵", Item::getSaku, () -> new IntegerSpinnerValueFactory(0, Integer.MAX_VALUE, 0)),
+                    new IntegerParameter<Item>("対潜", Item::getTais, () -> new IntegerSpinnerValueFactory(0, Integer.MAX_VALUE, 0)),
+                    new IntegerParameter<Item>("対空", Item::getTyku, () -> new IntegerSpinnerValueFactory(0, Integer.MAX_VALUE, 0)),
+                    new IntegerParameter<Item>("装甲", Item::getSouk, () -> new IntegerSpinnerValueFactory(0, Integer.MAX_VALUE, 0))
+            ).collect(Collectors.toList());
+        }
+
+        ItemParameterFilterPane() {
+            super(ITEM_PARAMETERS);
+        }
+    }
+
     /**
      * 基地航空隊のパラメータ用のペイン
      */

--- a/src/main/java/logbook/internal/gui/ParameterFilterPane.java
+++ b/src/main/java/logbook/internal/gui/ParameterFilterPane.java
@@ -234,4 +234,37 @@ abstract class ParameterFilterPane<T> extends GridPane {
             super(SHIPITEM_PARAMETERS);
         }
     }
+    
+    /**
+     * 基地航空隊のパラメータ用のペイン
+     */
+    static class AirBaseParameterFilterPane extends ParameterFilterPane<AirBaseItem> {
+        
+        private static final List<IntegerParameter<AirBaseItem>> AIRBASE_PARAMETERS;
+        
+        static {
+            AIRBASE_PARAMETERS = Stream.of(
+                    new IntegerParameter<AirBaseItem>("熟練", AirBaseItem::getAlv, () -> new IntegerSpinnerValueFactory(0, 7, 0)),
+                    new IntegerParameter<AirBaseItem>("改修", AirBaseItem::getLevel, () -> new IntegerSpinnerValueFactory(0, 10, 0)),
+                    new IntegerParameter<AirBaseItem>("所持", AirBaseItem::getCount, () -> new IntegerSpinnerValueFactory(1, Integer.MAX_VALUE, 1)),
+                    new IntegerParameter<AirBaseItem>("制空(出撃)", AirBaseItem::getSeiku, () -> new IntegerSpinnerValueFactory(0, Integer.MAX_VALUE, 103)),
+                    new IntegerParameter<AirBaseItem>("制空(防空)", AirBaseItem::getInterceptSeiku, () -> new IntegerSpinnerValueFactory(0, Integer.MAX_VALUE, 101)),
+                    new IntegerParameter<AirBaseItem>("半径(素)", AirBaseItem::getDistance, () -> new IntegerSpinnerValueFactory(0, Integer.MAX_VALUE, 7)),
+                    new IntegerParameter<AirBaseItem>("半径(+大艇)", AirBaseItem::getDistanceTaiteichan, () -> new IntegerSpinnerValueFactory(0, Integer.MAX_VALUE, 9)),
+                    new IntegerParameter<AirBaseItem>("半径(+Cata)", AirBaseItem::getDistanceCatalina, () -> new IntegerSpinnerValueFactory(0, Integer.MAX_VALUE, 10)),
+                    new IntegerParameter<AirBaseItem>("配置コスト", AirBaseItem::getCost, () -> new IntegerSpinnerValueFactory(0, Integer.MAX_VALUE, 100)),
+                    new IntegerParameter<AirBaseItem>("対空", AirBaseItem::getTyku, () -> new IntegerSpinnerValueFactory(0, Integer.MAX_VALUE, 5)),
+                    new IntegerParameter<AirBaseItem>("対爆", AirBaseItem::getHoum, () -> new IntegerSpinnerValueFactory(0, Integer.MAX_VALUE, 1)),
+                    new IntegerParameter<AirBaseItem>("迎撃", AirBaseItem::getHouk, () -> new IntegerSpinnerValueFactory(0, Integer.MAX_VALUE, 1)),
+                    new IntegerParameter<AirBaseItem>("雷装", AirBaseItem::getRaig, () -> new IntegerSpinnerValueFactory(0, Integer.MAX_VALUE, 1)),
+                    new IntegerParameter<AirBaseItem>("爆装", AirBaseItem::getBaku, () -> new IntegerSpinnerValueFactory(0, Integer.MAX_VALUE, 1)),
+                    new IntegerParameter<AirBaseItem>("対潜", AirBaseItem::getTais, () -> new IntegerSpinnerValueFactory(0, Integer.MAX_VALUE, 1)),
+                    new IntegerParameter<AirBaseItem>("索敵", AirBaseItem::getSaku, () -> new IntegerSpinnerValueFactory(0, Integer.MAX_VALUE, 1))
+            ).collect(Collectors.toList());
+        }
+
+        AirBaseParameterFilterPane() {
+            super(AIRBASE_PARAMETERS);
+        }
+    }
 }

--- a/src/main/resources/logbook/gui/item.fxml
+++ b/src/main/resources/logbook/gui/item.fxml
@@ -7,7 +7,7 @@
 
 <VBox prefHeight="600.0" prefWidth="800.0" styleClass="itemWindow" xmlns="http://javafx.com/javafx/8.0.162" xmlns:fx="http://javafx.com/fxml/1" fx:controller="logbook.internal.gui.ItemController">
    <children>
-      <TabPane VBox.vgrow="ALWAYS">
+      <TabPane fx:id="tab" VBox.vgrow="ALWAYS">
          <tabs>
             <Tab closable="false" text="全ての装備">
                <content>

--- a/src/main/resources/logbook/gui/item_airbase.fxml
+++ b/src/main/resources/logbook/gui/item_airbase.fxml
@@ -18,45 +18,7 @@
            <content>
               <VBox>
                  <children>
-                    <FlowPane>
-                       <children>
-                          <VBox fillWidth="false">
-                             <children>
-                                <ToggleSwitch fx:id="seikuFilter" prefWidth="0.0" text="制空(出撃)" />
-                              <Spinner fx:id="seikuValue" disable="true" editable="true" prefWidth="75.0" />
-                                <ChoiceBox fx:id="seikuType" disable="true" />
-                             </children>
-                          </VBox>
-                          <VBox fillWidth="false">
-                             <children>
-                                <ToggleSwitch fx:id="interceptSeikuFilter" prefWidth="0.0" text="制空(防空)" />
-                              <Spinner fx:id="interceptSeikuValue" disable="true" editable="true" prefWidth="75.0" />
-                                <ChoiceBox fx:id="interceptSeikuType" disable="true" />
-                             </children>
-                          </VBox>
-                          <VBox fillWidth="false">
-                             <children>
-                                <ToggleSwitch fx:id="distanceFilter" prefWidth="0.0" text="行動半径(素)" />
-                              <Spinner fx:id="distanceValue" disable="true" editable="true" prefWidth="75.0" />
-                                <ChoiceBox fx:id="distanceType" disable="true" />
-                             </children>
-                          </VBox>
-                          <VBox fillWidth="false">
-                             <children>
-                                <ToggleSwitch fx:id="distanceTaiteichanFilter" prefWidth="0.0" text="行動半径(二式大艇)" />
-                              <Spinner fx:id="distanceTaiteichanValue" disable="true" editable="true" prefWidth="75.0" />
-                                <ChoiceBox fx:id="distanceTaiteichanType" disable="true" />
-                             </children>
-                          </VBox>
-                          <VBox fillWidth="false">
-                             <children>
-                                <ToggleSwitch fx:id="distanceCatalinaFilter" prefWidth="0.0" text="行動半径(Catalina)" />
-                              <Spinner fx:id="distanceCatalinaValue" disable="true" editable="true" prefWidth="75.0" />
-                                <ChoiceBox fx:id="distanceCatalinaType" disable="true" />
-                             </children>
-                          </VBox>
-                       </children>
-                    </FlowPane>
+                    <FlowPane fx:id="filters" />
                  </children>
               </VBox>
            </content>

--- a/src/main/resources/logbook/gui/item_airbase.fxml
+++ b/src/main/resources/logbook/gui/item_airbase.fxml
@@ -14,7 +14,7 @@
 
 <VBox xmlns="http://javafx.com/javafx/8.0.162" xmlns:fx="http://javafx.com/fxml/1" fx:controller="logbook.internal.gui.ItemAirBaseController">
     <children>
-        <TitledPane animated="false" expanded="false" text="フィルター">
+        <TitledPane fx:id="filter" animated="false" expanded="false" text="フィルター">
            <content>
               <VBox>
                  <children>

--- a/src/main/resources/logbook/gui/item_item.fxml
+++ b/src/main/resources/logbook/gui/item_item.fxml
@@ -20,7 +20,7 @@
            <items>
               <VBox>
                  <children>
-                    <TitledPane animated="false" expanded="false" text="フィルター">
+                    <TitledPane fx:id="filter" animated="false" expanded="false" text="フィルター">
                    <content>
                       <FlowPane>
                          <children>

--- a/src/main/resources/logbook/gui/item_item.fxml
+++ b/src/main/resources/logbook/gui/item_item.fxml
@@ -22,7 +22,7 @@
                  <children>
                     <TitledPane fx:id="filter" animated="false" expanded="false" text="フィルター">
                    <content>
-                      <FlowPane>
+                      <FlowPane fx:id="filters" hgap="5" >
                          <children>
                             <VBox>
                                <children>

--- a/src/main/resources/logbook/gui/param_filter_pane.fxml
+++ b/src/main/resources/logbook/gui/param_filter_pane.fxml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.ChoiceBox?>
+<?import javafx.scene.control.Spinner?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.HBox?>
+<?import org.controlsfx.control.ToggleSwitch?>
+
+<fx:root prefWidth="120.0" type="GridPane" xmlns="http://javafx.com/javafx/8.0.162" xmlns:fx="http://javafx.com/fxml/1">
+   <children>
+      <HBox>
+         <ChoiceBox fx:id="parameter" disable="true" />
+         <ToggleSwitch fx:id="parameterFilter" prefWidth="0.0" />
+      </HBox>
+      <Spinner fx:id="parameterValue" disable="true" prefWidth="110.0"  GridPane.rowIndex="1"/>
+      <ChoiceBox fx:id="parameterValueChoice" visible="true" prefWidth="110.0"  GridPane.rowIndex="1"/>
+      <ChoiceBox fx:id="parameterType" disable="true" prefWidth="110.0"  GridPane.rowIndex="2"/>
+   </children>
+</fx:root>

--- a/src/main/resources/logbook/gui/ship_table.fxml
+++ b/src/main/resources/logbook/gui/ship_table.fxml
@@ -11,6 +11,7 @@
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.control.TitledPane?>
 <?import javafx.scene.layout.FlowPane?>
+<?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.text.TextFlow?>
 <?import org.controlsfx.control.ToggleSwitch?>
@@ -29,7 +30,7 @@
                               <TextField fx:id="textValue" disable="true" prefWidth="200.0" promptText="名前・艦種または装備" />
                            </children>
                         </FlowPane>
-                        <FlowPane>
+                        <FlowPane fx:id="filters" Hgap="5" Vgap="5">
                            <children>
                               <VBox fillWidth="false">
                                  <children>
@@ -58,20 +59,6 @@
                                           <CheckBox fx:id="allTypes" disable="true" mnemonicParsing="false" onAction="#allTypeAction" selected="true" text="すべて" />
                                        </children>
                                     </TextFlow>
-                                 </children>
-                              </VBox>
-                              <VBox fillWidth="false">
-                                 <children>
-                                    <ToggleSwitch fx:id="condFilter" prefWidth="0.0" text="コンディション" />
-                                    <TextField fx:id="conditionValue" disable="true" prefWidth="70.0" text="53" />
-                                    <ChoiceBox fx:id="conditionType" disable="true" />
-                                 </children>
-                              </VBox>
-                              <VBox fillWidth="false">
-                                 <children>
-                                    <ToggleSwitch fx:id="levelFilter" prefWidth="0.0" text="レベル" />
-                                    <TextField fx:id="levelValue" disable="true" prefWidth="70.0" text="98" />
-                                    <ChoiceBox fx:id="levelType" disable="true" />
                                  </children>
                               </VBox>
                               <VBox fillWidth="false">


### PR DESCRIPTION
#### 変更内容
所有艦娘および所有装備（装備一覧および基地航空隊）においては、装備一覧以外はフィルターがいくつか用意されていたが、事前に定義されたパラメータのみでしかフィルターできなかった。それをフィルターしたいパラメータを選択可能にし、それを複数組み合わせてフィルターできるように変更した。かつ、今までそれらのフィルターがなかった装備一覧にもフィルターを導入した。

#### 所有艦娘：
![image](https://user-images.githubusercontent.com/3181895/87952154-6db2a580-cae4-11ea-8486-33a5acf9b8f4.png)
#### 所有装備：
![image](https://user-images.githubusercontent.com/3181895/87953770-72785900-cae6-11ea-9a36-a714eda51d30.png)
#### 基地航空隊：
![image](https://user-images.githubusercontent.com/3181895/87953819-7e641b00-cae6-11ea-9d68-2c101ca92ec6.png)

#### 関連するIssue
Fixes #83

