### PR TITLE
44の遠征条件の修正 #204

### DIFF
--- a/src/main/resources/logbook/mission/7/44.json
+++ b/src/main/resources/logbook/mission/7/44.json
@@ -19,14 +19,30 @@
             ]
         },
         {
-            "operator": "AND",
+            "operator": "OR",
             "conditions": [
-                {"type": "艦娘", "ship_type" :["軽空母", "正規空母", "装甲空母"]},
-                {"type": "艦娘", "ship_type" :["軽空母", "正規空母", "装甲空母"]},
-                {"type": "艦娘", "ship_type" :["水上機母艦"]},
-                {"type": "艦娘", "ship_type" :["軽巡洋艦"]},
-                {"type": "艦娘", "ship_type" :["駆逐艦"]},
-                {"type": "艦娘", "ship_type" :["駆逐艦"]}
+                {
+                    "operator": "AND",
+                    "conditions": [
+                        {"type": "艦娘", "ship_type" :["軽空母", "正規空母", "装甲空母"]},
+                        {"type": "艦娘", "ship_type" :["水上機母艦"]},
+                        {"type": "艦娘", "ship_type" :["軽巡洋艦"]},
+                        {"type": "艦娘", "ship_type" :["駆逐艦"]},
+                        {"type": "艦娘", "ship_type" :["駆逐艦"]},
+                        {"type": "艦娘"}
+                    ]
+                },
+                {
+                    "operator": "AND",
+                    "conditions": [
+                        {"type": "艦娘", "ship_type" :["水上機母艦"]},
+                        {"type": "艦娘", "ship_type" :["水上機母艦"]},
+                        {"type": "艦娘", "ship_type" :["軽巡洋艦"]},
+                        {"type": "艦娘", "ship_type" :["駆逐艦"]},
+                        {"type": "艦娘", "ship_type" :["駆逐艦"]},
+                        {"type": "艦娘"}
+                    ]
+                }
             ]
         }
     ]


### PR DESCRIPTION
#### 問題解析
44の遠征条件が正しくない。条件は「全6隻。空母(水母,護母可)1隻、水母1隻、軽1隻、(駆+海防)2隻、他1隻必要」だが、 logbook-kai での定義は「空母2隻、水母1隻、軽1隻、(駆+海防)2隻」となっていた。

#### 変更内容
既存の条件の空母を1に減らして水母を追加するだけだと条件式の評価の実装上（艦隊の艦を最初からチェックし、条件に合致した艦を除いていく手法）うまくいかないので、式を二つ「空母1隻、水母1隻、軽1隻、(駆+海防)2隻、他1隻」か「水母2隻、軽1隻、(駆+海防)2隻、他1隻」とした。

#### 関連するIssue
Fixes #204

