### PR TITLE
cond値の表示色を改善する

### DIFF
--- a/src/main/java/logbook/internal/gui/FleetTabShipPane.java
+++ b/src/main/java/logbook/internal/gui/FleetTabShipPane.java
@@ -71,7 +71,9 @@ public class FleetTabShipPane extends HBox {
         this.hp.setText(this.ship.getNowhp() + "/" + this.ship.getMaxhp());
         this.supply.setImage(Ships.supplyGaugeImage(this.ship));
         this.cond.setText(this.ship.getCond() + "cond.");
-
+        if (this.ship.getNowhp() == this.ship.getMaxhp()) {
+            this.hp.getStyleClass().add("hp-max");
+        }
         ObservableList<String> styleClass = this.cond.getStyleClass();
         styleClass.clear();
         styleClass.add("label");

--- a/src/main/resources/logbook/gui/main.css
+++ b/src/main/resources/logbook/gui/main.css
@@ -46,6 +46,9 @@ TabPane .tab.empty .tab-label {
 .hp {
     -fx-min-width: 4.25em;
 }
+.hp-max {
+    -fx-text-fill: rgb(0, 0, 192);
+}
 .deepgreen {
     -fx-text-fill: rgb(0, 160, 0);
 }

--- a/src/main/resources/logbook/gui/main.css
+++ b/src/main/resources/logbook/gui/main.css
@@ -47,16 +47,22 @@ TabPane .tab.empty .tab-label {
     -fx-min-width: 4.25em;
 }
 .deepgreen {
-    -fx-text-fill: rgb(0, 60, 0);
+    -fx-text-fill: rgb(0, 160, 0);
 }
 .green {
-    -fx-text-fill: rgb(0, 128, 0);
+    -fx-text-fill: rgb(0, 160, 0);
+    -fx-font-weight: bold;
+    -fx-background-color: rgba(0, 160, 0, 0.1);
 }
 .orange {
     -fx-text-fill: rgb(255, 140, 0);
+    -fx-font-weight: bold;
+    -fx-background-color: rgba(255, 140, 0, 0.1);
 }
 .red {
     -fx-text-fill: rgb(255, 16, 0);
+    -fx-font-weight: bold;
+    -fx-background-color: rgba(255, 16, 0, 0.1);
 }
 .value {
     -fx-font-size: 1.1em;

--- a/src/main/resources/logbook/gui/ship.css
+++ b/src/main/resources/logbook/gui/ship.css
@@ -8,16 +8,22 @@
 }
 
 TabPane .deepgreen {
-    -fx-text-fill: rgb(0, 60, 0);
+    -fx-text-fill: rgb(0, 160, 0);
 }
 TabPane .green {
-    -fx-text-fill: rgb(0, 128, 0);
+    -fx-text-fill: rgb(0, 160, 0);
+    -fx-font-weight: bold;
+    -fx-background-color: rgba(0, 160, 0, 0.1);
 }
 TabPane .orange {
     -fx-text-fill: rgb(255, 140, 0);
+    -fx-font-weight: bold;
+    -fx-background-color: rgba(255, 140, 0, 0.1);
 }
 TabPane .red {
     -fx-text-fill: rgb(255, 16, 0);
+    -fx-font-weight: bold;
+    -fx-background-color: rgba(255, 16, 0, 0.1);
 }
 .table-row-cell .none {
     -fx-background-color: lightgray;


### PR DESCRIPTION
#### 変更内容
cond 値の変化がより視覚的にわかるように変更を行った。30-52以外の cond 値の場合は太字にし、かつ文字の背景に色を付けて視認しやすいようにした。

![image](https://user-images.githubusercontent.com/3181895/88190242-02e4a400-cc75-11ea-9157-e28abbcfe2e8.png)

統一感を持たせるため以下のルールにした。
- 状態分けは従来通り 0-19, 20-29, 30-49, 50-52, 53-100
- 二段キラ(53以上)と疲労(29以下)は通常状態とは違うということでboldにし、背景色をつける
- 背景色は文字色と同じでアルファ(透明度)0.1で調整する

またHPが満タンの場合にHPの表示を青で表示するようにした。

#### 関連するIssue
Fixes #198

