### PR TITLE
経験値・HPゲージの背景の透明度を落とす #200

### DIFF
--- a/src/main/java/logbook/internal/ShipImage.java
+++ b/src/main/java/logbook/internal/ShipImage.java
@@ -397,7 +397,8 @@ class ShipImage {
                 expPer = 0;
             }
         } else {
-            expPer = 0;
+            // 既に max の場合は表示しない
+            return;
         }
         Color color = Color.TRANSPARENT.interpolate(Color.DEEPSKYBLUE, 0.9);
         gc.drawImage(createGauge(w, gaugeHeight, expPer, k -> color, EXPGAUGE_CACHE), 0, h - gaugeHeight);
@@ -419,7 +420,7 @@ class ShipImage {
         return cache.get(size, key -> {
             Canvas canvas = new Canvas(width, height);
             GraphicsContext gc = canvas.getGraphicsContext2D();
-            gc.setFill(Color.TRANSPARENT.interpolate(Color.WHITE, 0.6));
+            gc.setFill(Color.TRANSPARENT.interpolate(Color.ALICEBLUE, 0.9));
             if (width < height) {
                 gc.fillRect(0, 0, width, height - size);
             } else {


### PR DESCRIPTION
#### 変更内容
経験値・HPゲージの背景色がグレーで見難いという声を受けて、ツイッターで背景を白にするアンケートを取ってみたところ、現状維持が 53%、白抜きが47%となり、ほぼ拮抗した。現状維持の意見は色の感じが現状のままのほうがよい（目立ちすぎない）という意見で、白抜きが良いという意見はゲージの量が見難いという意見だと考えられ、かつリプライで見難いのは色のせいではなく背景が透けているせいではないかという意見もあった。実際に調査してみると、背景色は実際すでに白で、アルファが0.6（40%透ける）だったことがわかった。背景色は特にグラデーションもしていないが、実際の印象は右に行くほどグレーが濃くなっているように見える。その理由は背景になっている艦娘バナー画像が
![image](https://user-images.githubusercontent.com/3181895/87998931-53081d00-cb34-11ea-9cf2-45dfd6194d70.png)
のように右下に黒い線が入っており、ちょうどそこに透明度がある程度高い背景色が重なるためなせいなこともわかった。

そこで背景色のアルファを0.6から0.9に変更した（同時に白で0.9だとかなり強く見えるので少し色を落とした）。また、経験値が max、レベル99または175の艦については経験値ゲージは表示しないようにした。

![image](https://user-images.githubusercontent.com/3181895/88350021-c2784980-cd8c-11ea-9404-73b7108e3d30.png)

#### 関連するIssue
Fixes #200

