### PR TITLE
Java11 で起動した場合 -java11 のパッケージをダウンロードする

### DIFF
--- a/src/main/resources/logbook/update/update.js
+++ b/src/main/resources/logbook/update/update.js
@@ -7,6 +7,7 @@ load("fx:graphics.js");
 load("fx:web.js");
 // import
 var System = java.lang.System;
+var Boolean = java.lang.Boolean;
 var BufferedReader = java.io.BufferedReader;
 var InputStream = java.io.InputStream;
 var InputStreamReader = java.io.InputStreamReader;
@@ -27,6 +28,8 @@ var scriptFile = System.getProperty("update_script");
 var targetDir = System.getProperty("install_target");
 // インストールバージョン
 var version = System.getProperty("install_version");
+// Prerelease を使うかどうか
+var usePrerelease = System.getProperty("use_prerelease");
 // GitHub Releases API
 var releaseURL = "https://api.github.com/repos/sanaehirotaka/logbook-kai/releases/tags/v" + version;
 var release = {};
@@ -64,13 +67,14 @@ UpdateTask.prototype.getReleaseJson = function() {
             release = JSON.parse(jsonText);
 
             if (release["assets"]) {
-                if (release["prerelease"] || release["draft"]) {
+                if ((!Boolean.parseBoolean(usePrerelease) && release["prerelease"]) || release["draft"]) {
                     var msg = release["name"] + "は試験的なバージョンであるため更新されませんでした。手動での更新をお願いします。";
                     throw msg;
                 }
                 for (var i = 0; i < release["assets"].length; i++) {
                     var name = release["assets"][i]["name"];
-                    if (name.startsWith("logbook-kai_") && name.endsWith(".zip")) {
+                    var prefix = "11".equals(System.getProperty("target_java_version")) ? "logbook-kai-java11_" : "logbook-kai_";
+                    if (name.startsWith(prefix) && name.endsWith(".zip")) {
                         asset = release["assets"][i];
                         break;
                     }


### PR DESCRIPTION
#### 変更内容
Java11 のパッケージ配布方法はまだ未定ではあるが（ #208 など）、次のバージョンのリリースまでには Java 11 版の自動更新に対応しておく必要があるため（でないと次のバージョンを配布するときにまた手動になる）、スクリプトを更新しておく。本体側で利用している Java のバージョンを調べ、`11` だったら -java11 を利用するようにする。（現時点ではまだベータなのでJava 12以降は想定していない。）

また、開発用途として `logbook.use.prerelease=true` をセットして起動した場合は Prerelease のものでも自動更新するようにする。

いずれの場合も本体側でこれらの条件を調べ、スクリプトには `-D` で渡すように実装している。