### PR TITLE
パラメータフィルターの型を保存と細かな修正 #210

### DIFF
--- a/src/main/java/logbook/internal/gui/ParameterFilterPane.java
+++ b/src/main/java/logbook/internal/gui/ParameterFilterPane.java
@@ -123,6 +123,7 @@ abstract class ParameterFilterPane<T> extends GridPane {
         this.parameterFilter.selectedProperty().addListener((ob, ov, nv) -> {
             this.parameter.setDisable(!nv);
             this.parameterValue.setDisable(!nv);
+            this.parameterValueChoice.setDisable(!nv);
             this.parameterType.setDisable(!nv);
         });
         this.parameterValue.setEditable(true);
@@ -176,6 +177,7 @@ abstract class ParameterFilterPane<T> extends GridPane {
             Optional.ofNullable(parameterFilterConfig.getValue()).ifPresent(this.parameterValue.getValueFactory()::setValue);
         }
         Optional.ofNullable(parameterFilterConfig.getValueChoice()).ifPresent(this.parameterValueChoice.getSelectionModel()::select);
+        Optional.ofNullable(parameterFilterConfig.getType()).ifPresent(this.parameterType.getSelectionModel()::select);
     }
     
     /**
@@ -194,6 +196,7 @@ abstract class ParameterFilterPane<T> extends GridPane {
         }
         Optional.ofNullable(value).ifPresent(config::setValue);
         Optional.ofNullable(this.parameterValueChoice.getValue()).ifPresent(config::setValueChoice);
+        Optional.ofNullable(this.parameterType.getValue()).ifPresent(config::setType);
         return config;
     }
 

--- a/src/main/java/logbook/internal/gui/ShipTablePane.java
+++ b/src/main/java/logbook/internal/gui/ShipTablePane.java
@@ -1052,10 +1052,9 @@ public class ShipTablePane extends VBox {
         @Override
         protected void updateItem(Integer cond, boolean empty) {
             super.updateItem(cond, empty);
-
+            ObservableList<String> styleClass = this.getStyleClass();
+            styleClass.removeAll("deepgreen", "green", "orange", "red");
             if (!empty) {
-                ObservableList<String> styleClass = this.getStyleClass();
-                styleClass.removeAll("deepgreen", "green", "orange", "red");
                 if (cond >= Ships.DARK_GREEN && cond < Ships.GREEN) {
                     styleClass.add("deepgreen");
                 } else if (cond >= Ships.GREEN) {

--- a/src/main/resources/logbook/gui/param_filter_pane.fxml
+++ b/src/main/resources/logbook/gui/param_filter_pane.fxml
@@ -13,7 +13,7 @@
          <ToggleSwitch fx:id="parameterFilter" prefWidth="0.0" />
       </HBox>
       <Spinner fx:id="parameterValue" disable="true" prefWidth="110.0"  GridPane.rowIndex="1"/>
-      <ChoiceBox fx:id="parameterValueChoice" visible="true" prefWidth="110.0"  GridPane.rowIndex="1"/>
+      <ChoiceBox fx:id="parameterValueChoice" disable="true" visible="false" prefWidth="110.0"  GridPane.rowIndex="1"/>
       <ChoiceBox fx:id="parameterType" disable="true" prefWidth="110.0"  GridPane.rowIndex="2"/>
    </children>
 </fx:root>


### PR DESCRIPTION
#### 問題解析
`ParameterFiterPane` の save/load で `type` についての処理がごっそり抜けおちているため。艦娘一覧、装備一覧（装備・基地航空隊）全てにおいて再現を確認。

#### 変更内容
Save/Load のコードを追加。また、数値型ではあるが Choice で実装されているカラムが選択されていた場合、 toggle をオフにしている時にでも enabled な状態で load されていたのを修正。同時に空のセルの背景に色がつく場合があったのを修正。

#### 関連するIssue
Fixes #210

