### PR TITLE
デッキビルダー形式の出力サポートと関連する変更

### DIFF
--- a/src/main/java/logbook/bean/AppConfig.java
+++ b/src/main/java/logbook/bean/AppConfig.java
@@ -69,6 +69,9 @@ public final class AppConfig implements Serializable {
     /** 戦闘結果時に結果を反映 */
     private boolean applyResult = true;
 
+    /** 艦隊タブに全艦隊のタブを追加 */
+    private boolean allDecksTab = false;
+
     /** 艦隊タブに艦隊単位のタブを追加 */
     private boolean deckTabs = false;
 

--- a/src/main/java/logbook/bean/AppItemTableConfig.java
+++ b/src/main/java/logbook/bean/AppItemTableConfig.java
@@ -48,6 +48,9 @@ public class AppItemTableConfig {
         /** フィルターが展開されていたかどうか */
         private boolean filterExpanded;
 
+        /** グルーピングをしない */
+        private boolean disableGrouping;
+
         /** パラメータフィルター */
         private List<ParameterFilterConfig> parameterFilters;
     }

--- a/src/main/java/logbook/bean/AppShipTableConfig.java
+++ b/src/main/java/logbook/bean/AppShipTableConfig.java
@@ -14,6 +14,9 @@ import lombok.Data;
 @Data
 public class AppShipTableConfig {
 
+    /** 開いていたタブ */
+    private int tabIndex;
+    
     /** タブ別の設定 */
     private Map<String, AppShipTableTabConfig> tabConfig = new LinkedHashMap<>();
 

--- a/src/main/java/logbook/internal/gui/AirBaseController.java
+++ b/src/main/java/logbook/internal/gui/AirBaseController.java
@@ -181,6 +181,18 @@ public class AirBaseController extends WindowController {
         }
     }
 
+    @FXML
+    void deckBuilderCopy() {
+        List<AirBase> airbases = new ArrayList<>();
+        addItem(airbases, this.areaTable.getSelectionModel().getSelectedItem());
+        DeckBuilder.airbaseSelectionCopy(airbases);
+    }
+    
+    void addItem(List<AirBase> list, TreeItem<AreaTable> item) {
+        Optional.ofNullable(item.getValue()).map(AreaTable::getAirBase).ifPresent(list::add);
+        Optional.ofNullable(item.getChildren()).ifPresent(children -> children.forEach(child -> addItem(list, child)));
+    }
+
     /**
      * クリップボードにコピー
      */

--- a/src/main/java/logbook/internal/gui/AirBaseItem.java
+++ b/src/main/java/logbook/internal/gui/AirBaseItem.java
@@ -614,6 +614,7 @@ public class AirBaseItem implements Comparable<AirBaseItem> {
         abitem.setBaku(slotitem.getBaku());
         abitem.setTais(slotitem.getTais());
         abitem.setSaku(slotitem.getSaku());
+        abitem.setCount(1);
         return abitem;
     }
 

--- a/src/main/java/logbook/internal/gui/ConfigController.java
+++ b/src/main/java/logbook/internal/gui/ConfigController.java
@@ -172,6 +172,10 @@ public class ConfigController extends WindowController {
     @FXML
     private TextField imageZoomRate;
 
+    /** 艦隊タブに全艦隊のタブを追加 */
+    @FXML
+    private CheckBox allDecksTab;
+
     /** 艦隊タブに艦隊単位のタブを追加 */
     @FXML
     private CheckBox deckTabs;
@@ -390,6 +394,7 @@ public class ConfigController extends WindowController {
         this.shipFullyThreshold.setText(Integer.toString(conf.getShipFullyThreshold()));
         this.itemFullyThreshold.setText(Integer.toString(conf.getItemFullyThreshold()));
         this.imageZoomRate.setText(Integer.toString(conf.getImageZoomRate()));
+        this.allDecksTab.setSelected(conf.isAllDecksTab());
         this.deckTabs.setSelected(conf.isDeckTabs());
         this.labelTabs.setSelected(conf.isLabelTabs());
         this.tabColorNoDamage.setText(conf.getTabColorNoDamage());
@@ -516,6 +521,7 @@ public class ConfigController extends WindowController {
         conf.setShipFullyThreshold(this.toInt(this.shipFullyThreshold.getText()));
         conf.setItemFullyThreshold(this.toInt(this.itemFullyThreshold.getText()));
         conf.setImageZoomRate(this.toInt(this.imageZoomRate.getText()));
+        conf.setAllDecksTab(this.allDecksTab.isSelected());
         conf.setDeckTabs(this.deckTabs.isSelected());
         conf.setLabelTabs(this.labelTabs.isSelected());
         conf.setTabColorNoDamage(this.tabColorNoDamage.getText());

--- a/src/main/java/logbook/internal/gui/DeckBuilder.java
+++ b/src/main/java/logbook/internal/gui/DeckBuilder.java
@@ -1,0 +1,207 @@
+package logbook.internal.gui;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import javafx.scene.control.TableView;
+import javafx.scene.input.Clipboard;
+import javafx.scene.input.ClipboardContent;
+import logbook.bean.Basic;
+import logbook.bean.DeckPortCollection;
+import logbook.bean.Ship;
+import logbook.bean.ShipCollection;
+import logbook.bean.SlotItem;
+import logbook.bean.SlotItemCollection;
+import logbook.bean.Mapinfo.AirBase;
+import logbook.bean.Mapinfo.PlaneInfo;
+import lombok.Data;
+
+/**
+ * デッキビルダー形式の出力
+ */
+public class DeckBuilder {
+
+    /**
+     * 表示されている艦をクリップボードにコピーする。
+     *
+     * @param table テーブル
+     */
+    public static void displayCopy(TableView<ShipItem> table) {
+        copyToClipboard(table.getItems()
+                .stream()
+                .map(ShipItem::getShip)
+                .collect(Collectors.toList()), null);
+    }
+
+    /**
+     * 選択された艦のみをクリップボードにコピーする。
+     *
+     * @param table テーブル
+     */
+    public static void selectionCopy(TableView<ShipItem> table) {
+        copyToClipboard(table.getSelectionModel()
+                .getSelectedItems()
+                .stream()
+                .map(ShipItem::getShip)
+                .collect(Collectors.toList()), null);
+    }
+    
+    /**
+     * 選択された基地航空隊の機体リストをクリップボードにコピーする。
+     * 艦隊部分は現在の艦隊が入る。
+     * 
+     * @param table テーブル
+     */
+    public static void airbaseSelectionCopy(TableView<AirBaseItem> table) {
+        Airbase ab = new Airbase();
+        List<Airbase> all = new ArrayList<>();
+        all.add(ab);
+        for (AirBaseItem item : table.getSelectionModel().getSelectedItems()) {
+            if (ab.getList().size() == 4) {
+                ab = new Airbase();
+                all.add(ab);
+            }
+            ab.getList().add(item);
+        }
+        copyToClipboard(ShipCollection.get().getShipMap().values(), all);
+    }
+    
+    /**
+     * 選択された基地航空隊をクリップボードにコピーする。
+     * 艦隊部分は現在の艦隊が入る。
+     * 
+     * @param airbases 基地航空隊
+     */
+    public static void airbaseSelectionCopy(List<AirBase> airbases) {
+        List<Airbase> list = IntStream.range(1, 4)
+            .mapToObj(id -> airbases.stream().filter(ab -> ab.getRid() == id).findAny())
+            .map(ab -> ab.map(Airbase::new).orElse(new Airbase()))
+            .collect(Collectors.toList());
+        copyToClipboard(ShipCollection.get().getShipMap().values(), list);
+    }
+
+    private static void copyToClipboard(Collection<Ship> ships, List<Airbase> airbase) {
+        Set<Integer> targets = ships.stream().map(Ship::getId).collect(Collectors.toSet());
+        Map<Integer, Ship> shipsMap = ShipCollection.get().getShipMap();
+        Map<String, Object> data = new TreeMap<>();
+        data.put("version", 4);
+        Optional.ofNullable(Basic.get().getLevel()).ifPresent(lv -> data.put("hqlv", lv));
+        DeckPortCollection.get().getDeckPortMap().values().stream().forEach(port -> {
+            Map<String, DeckBuilder.Kanmusu> fleet = new TreeMap<>();
+            Optional.ofNullable(port.getShip()).ifPresent(list -> {
+                for (int i = 0; i < list.size(); i++) {
+                    final int index = i+1;
+                    Optional.ofNullable(list.get(i))
+                        .filter(targets::contains)
+                        .map(shipsMap::get)
+                        .map(DeckBuilder.Kanmusu::new)
+                        .ifPresent(kanmusu -> fleet.put("s" + index, kanmusu));
+                }
+            });
+            data.put("f" + port.getId(), fleet);
+        });
+        Optional.ofNullable(airbase).ifPresent(list -> {
+            for (int a = 0; a < airbase.size(); a++) {
+                Airbase ab = airbase.get(a);
+                if (ab.getList() != null && ab.getList().size() > 0) {
+                    data.put("a" + (a+1), ab);
+                    List<AirBaseItem> planes = ab.getList();
+                    for (int i = 0; i < planes.size(); i++) {
+                        Item item = new Item(planes.get(i));
+                        ab.getItems().put("i" + (i+1), item);
+                    }
+                }
+            }
+        });
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            ClipboardContent content = new ClipboardContent();
+            content.putString(mapper.writeValueAsString(data));
+            Clipboard.getSystemClipboard().setContent(content);
+        } catch (JsonProcessingException e) {
+            // ignore
+        }
+    }
+
+    @Data
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    private static class Item {
+        private final int id;
+        private final Integer rf;
+        private final Integer mas;
+        
+        Item(SlotItem item) {
+            this.id = item.getSlotitemId();
+            this.rf = item.getLevel();
+            this.mas = item.getAlv();
+        }
+        
+        Item(AirBaseItem item) {
+            this.id = item.getId();
+            this.rf = item.getLevel();
+            this.mas = item.getAlv();
+        }
+    }
+
+    @Data
+    private static class Kanmusu {
+        private final int id;
+        private final int lv;
+        private final int luck;
+        private Map<String, DeckBuilder.Item> items;
+        
+        Kanmusu(Ship ship) {
+            this.id = ship.getShipId();
+            this.lv = ship.getLv();
+            this.luck = ship.getLucky().get(0);
+            this.items = new TreeMap<>();
+            Map<Integer, SlotItem> slotitemMap = SlotItemCollection.get().getSlotitemMap();
+            Optional.ofNullable(ship.getSlot())
+                .ifPresent(slot -> {
+                    for (int i = 0; i < slot.size(); i++) {
+                        final int index = i+1;
+                        Optional.ofNullable(slot.get(i))
+                            .map(slotitemMap::get)
+                            .map(DeckBuilder.Item::new)
+                            .ifPresent(item -> this.items.put("i"+(index), item));
+                    }
+                });
+            Optional.ofNullable(ship.getSlotEx())
+                .map(slotitemMap::get)
+                .map(DeckBuilder.Item::new)
+                .ifPresent(item -> this.items.put("ix", item));
+        }
+    }
+    
+    @Data
+    private static class Airbase {
+        private int mode = 1;     // default
+        private final Map<String, DeckBuilder.Item> items = new TreeMap<>();
+        @JsonIgnore
+        private List<AirBaseItem> list;
+        
+        Airbase() {
+            this.list = new ArrayList<>();
+        }
+        
+        Airbase(AirBase ab) {
+            this.mode = ab.getActionKind();
+            if (ab != null && ab.getPlaneInfo() != null) {
+                Map<Integer, SlotItem> map = SlotItemCollection.get().getSlotitemMap();
+                this.list = ab.getPlaneInfo().stream().map(PlaneInfo::getSlotid).map(map::get).map(AirBaseItem::toAirBaseItem).collect(Collectors.toList());
+            }
+        }
+    }
+}

--- a/src/main/java/logbook/internal/gui/ItemAirBaseController.java
+++ b/src/main/java/logbook/internal/gui/ItemAirBaseController.java
@@ -359,7 +359,7 @@ public class ItemAirBaseController extends WindowController {
      */
     @FXML
     void deckBuilderSelectionCopy() {
-        ShipTablePane.DeckBuilder.airbaseSelectionCopy(this.itemTable);
+        DeckBuilder.airbaseSelectionCopy(this.itemTable);
     }
 
     /**

--- a/src/main/java/logbook/internal/gui/ItemAirBaseController.java
+++ b/src/main/java/logbook/internal/gui/ItemAirBaseController.java
@@ -328,6 +328,14 @@ public class ItemAirBaseController extends WindowController {
     }
 
     /**
+     * (基地航空隊)デッキビルダー形式でクリップボードにコピー
+     */
+    @FXML
+    void deckBuilderSelectionCopy() {
+        ShipTablePane.DeckBuilder.airbaseSelectionCopy(this.itemTable);
+    }
+
+    /**
      * (基地航空隊)テーブル列の表示・非表示の設定
      */
     @FXML

--- a/src/main/java/logbook/internal/gui/ShipController.java
+++ b/src/main/java/logbook/internal/gui/ShipController.java
@@ -70,6 +70,10 @@ public class ShipController extends WindowController {
 
             this.tab.getTabs().add(new Tab("全員", allPane));
 
+            // 全艦隊のタブ
+            if (AppConfig.get().isAllDecksTab()) {
+                this.addAllDecksTab();
+            }
             // 艦隊単位のタブ
             if (AppConfig.get().isDeckTabs()) {
                 this.addDeckTabs();
@@ -91,6 +95,23 @@ public class ShipController extends WindowController {
         } catch (Exception e) {
             LoggerHolder.get().error("FXMLの初期化に失敗しました", e);
         }
+    }
+
+    /**
+     * 全艦隊のタブ
+     */
+    private void addAllDecksTab() {
+        ShipTablePane deckPane = new ShipTablePane(() -> {
+            Map<Integer, Ship> shipMap = ShipCollection.get()
+                    .getShipMap();
+            return DeckPortCollection.get().getDeckPortMap().values().stream()
+                .map(DeckPort::getShip)
+                .flatMap(List::stream)
+                .map(shipMap::get)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+        }, "全艦隊");
+        this.tab.getTabs().add(new Tab("全艦隊", deckPane));
     }
 
     /**

--- a/src/main/java/logbook/internal/gui/ShipController.java
+++ b/src/main/java/logbook/internal/gui/ShipController.java
@@ -18,6 +18,7 @@ import javafx.scene.control.TabPane;
 import javafx.stage.WindowEvent;
 import javafx.util.Duration;
 import logbook.bean.AppConfig;
+import logbook.bean.AppShipTableConfig;
 import logbook.bean.DeckPort;
 import logbook.bean.DeckPortCollection;
 import logbook.bean.Ship;
@@ -82,6 +83,15 @@ public class ShipController extends WindowController {
             if (AppConfig.get().isLabelTabs()) {
                 this.addLabelTabs();
             }
+            int index = AppShipTableConfig.get().getTabIndex();
+            if (index < this.tab.getTabs().size()) {
+                this.tab.getSelectionModel().select(index);
+            }
+            this.tab.getSelectionModel().selectedIndexProperty().addListener((ob, o, n) -> {
+                if (n != null) {
+                    AppShipTableConfig.get().setTabIndex(n.intValue());
+                }
+            });
 
             this.addStatistics();
 

--- a/src/main/java/logbook/internal/gui/ShipTablePane.java
+++ b/src/main/java/logbook/internal/gui/ShipTablePane.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -23,7 +24,9 @@ import java.util.stream.Collectors;
 import org.controlsfx.control.ToggleSwitch;
 import org.controlsfx.control.textfield.TextFields;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import javafx.beans.property.ReadOnlyObjectProperty;
@@ -59,6 +62,7 @@ import javafx.stage.Stage;
 import logbook.bean.AppConfig;
 import logbook.bean.AppShipTableConfig;
 import logbook.bean.AppShipTableConfig.AppShipTableTabConfig;
+import logbook.bean.Basic;
 import logbook.bean.DeckPort;
 import logbook.bean.DeckPortCollection;
 import logbook.bean.Ship;
@@ -788,6 +792,23 @@ public class ShipTablePane extends VBox {
             LoggerHolder.get().error("艦隊分析のロック装備をクリップボードにコピーに失敗しました", e);
         }
     }
+
+    /**
+     * デッキビルダー形式：表示されている艦をクリップボードにコピー
+     */
+    @FXML
+    void deckBuilderDisplayCopy() {
+        DeckBuilder.displayCopy(this.table);
+    }
+
+    /**
+     * デッキビルダー形式：選択した艦のみクリップボードにコピー
+     */
+    @FXML
+    void deckBuilderSelectionCopy() {
+        DeckBuilder.selectionCopy(this.table);
+    }
+
     /**
      * テーブル列の表示・非表示の設定
      */
@@ -1293,4 +1314,111 @@ public class ShipTablePane extends VBox {
         }
     }
 
+    /**
+     * デッキビルダー形式の出力
+     */
+    public static class DeckBuilder {
+
+        /**
+         * 表示されている艦をクリップボードにコピーする。
+         *
+         * @param table テーブル
+         */
+        public static void displayCopy(TableView<ShipItem> table) {
+            ClipboardContent content = new ClipboardContent();
+            content.putString(text(table.getItems()
+                    .stream()
+                    .map(ShipItem::getShip)
+                    .collect(Collectors.toList())));
+            Clipboard.getSystemClipboard().setContent(content);
+        }
+
+        /**
+         * 選択された艦のみをクリップボードにコピーする。
+         *
+         * @param table テーブル
+         */
+        public static void selectionCopy(TableView<ShipItem> table) {
+            ClipboardContent content = new ClipboardContent();
+            content.putString(text(table.getSelectionModel()
+                    .getSelectedItems()
+                    .stream()
+                    .map(ShipItem::getShip)
+                    .collect(Collectors.toList())));
+            Clipboard.getSystemClipboard().setContent(content);
+        }
+
+        private static String text(Collection<Ship> ships) {
+            Set<Integer> targets = ships.stream().map(Ship::getId).collect(Collectors.toSet());
+            Map<Integer, Ship> shipsMap = ShipCollection.get().getShipMap();
+            Map<String, Object> data = new TreeMap<>();
+            data.put("version", 4);
+            Optional.ofNullable(Basic.get().getLevel()).ifPresent(lv -> data.put("hqlv", lv));
+            DeckPortCollection.get().getDeckPortMap().values().stream().forEach(port -> {
+                Map<String, Kanmusu> fleet = new TreeMap<>();
+                Optional.ofNullable(port.getShip()).ifPresent(list -> {
+                    for (int i = 0; i < list.size(); i++) {
+                        final int index = i+1;
+                        Optional.ofNullable(list.get(i))
+                            .filter(targets::contains)
+                            .map(shipsMap::get)
+                            .map(Kanmusu::new)
+                            .ifPresent(kanmusu -> fleet.put("s" + index, kanmusu));
+                    }
+                });
+                data.put("f" + port.getId(), fleet);
+            });
+            ObjectMapper mapper = new ObjectMapper();
+            try {
+                return mapper.writeValueAsString(data);
+            } catch (JsonProcessingException e) {
+                // ignore
+            }
+            return null;
+        }
+
+        @Data
+        @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+        private static class Item {
+            private final int id;
+            private final Integer rf;
+            private final Integer mas;
+            
+            Item(SlotItem item) {
+                this.id = item.getSlotitemId();
+                this.rf = item.getLevel();
+                this.mas = item.getAlv();
+            }
+        }
+
+        @Data
+        private static class Kanmusu {
+            private final int id;
+            private final int lv;
+            private final int luck;
+            private Map<String, Item> items;
+            
+            Kanmusu(Ship ship) {
+                this.id = ship.getShipId();
+                this.lv = ship.getLv();
+                this.luck = ship.getLucky().get(0);
+                this.items = new TreeMap<>();
+                Map<Integer, SlotItem> slotitemMap = SlotItemCollection.get().getSlotitemMap();
+                Optional.ofNullable(ship.getSlot())
+                    .ifPresent(slot -> {
+                        for (int i = 0; i < slot.size(); i++) {
+                            final int index = i+1;
+                            Optional.ofNullable(slot.get(i))
+                                .map(slotitemMap::get)
+                                .map(Item::new)
+                                .ifPresent(item -> this.items.put("i"+(index), item));
+                        }
+                    });
+                Optional.ofNullable(ship.getSlotEx())
+                    .map(slotitemMap::get)
+                    .map(Item::new)
+                    .ifPresent(item -> this.items.put("ix", item));
+            }
+        }
+    }
 }

--- a/src/main/java/logbook/internal/gui/ShipTablePane.java
+++ b/src/main/java/logbook/internal/gui/ShipTablePane.java
@@ -23,6 +23,9 @@ import java.util.stream.Collectors;
 import org.controlsfx.control.ToggleSwitch;
 import org.controlsfx.control.textfield.TextFields;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.beans.value.ObservableValue;
 import javafx.collections.FXCollections;
@@ -764,6 +767,28 @@ public class ShipTablePane extends VBox {
     }
 
     /**
+     * 艦隊分析
+     */
+    @FXML
+    void kancolleFleetanalysis() {
+        try {
+            List<KancolleFleetanalysisItem> list = ShipCollection.get().getShipMap().values().stream()
+                    .filter(ship -> ship.getLocked())
+                    .map(KancolleFleetanalysisItem::toItem)
+                    .sorted(Comparator.comparing(KancolleFleetanalysisItem::getId)
+                            .thenComparing(Comparator.comparing(KancolleFleetanalysisItem::getLv)))
+                    .collect(Collectors.toList());
+            ObjectMapper mapper = new ObjectMapper();
+            String input = mapper.writeValueAsString(list);
+
+            ClipboardContent content = new ClipboardContent();
+            content.putString(input);
+            Clipboard.getSystemClipboard().setContent(content);
+        } catch (Exception e) {
+            LoggerHolder.get().error("艦隊分析のロック装備をクリップボードにコピーに失敗しました", e);
+        }
+    }
+    /**
      * テーブル列の表示・非表示の設定
      */
     @FXML
@@ -1243,6 +1268,28 @@ public class ShipTablePane extends VBox {
             public String toString() {
                 return this.lv + "." + this.ship.kai;
             }
+        }
+    }
+
+
+    @Data
+    @AllArgsConstructor
+    private static class KancolleFleetanalysisItem {
+
+        @JsonProperty("api_ship_id")
+        private int id;
+
+        @JsonProperty("api_lv")
+        private int lv;
+
+        @JsonProperty("api_kyouka")
+        private List<Integer> kyouka;
+
+        @JsonProperty("api_exp")
+        private List<Integer> exp;
+
+        public static KancolleFleetanalysisItem toItem(Ship ship) {
+            return new KancolleFleetanalysisItem(ship.getShipId(), ship.getLv(), ship.getKyouka(), ship.getExp());
         }
     }
 

--- a/src/main/resources/logbook/gui/airbase.fxml
+++ b/src/main/resources/logbook/gui/airbase.fxml
@@ -25,6 +25,13 @@
                   <TreeTableColumn fx:id="seiku" prefWidth="50.0" text="制空" />
                   <TreeTableColumn fx:id="distance" prefWidth="50.0" text="半径" />
               </columns>
+              <contextMenu>
+                <ContextMenu>
+                  <items>
+                      <MenuItem mnemonicParsing="false" onAction="#deckBuilderCopy" text="デッキビルダー形式のデータをクリップボードにコピー" />
+                  </items>
+                </ContextMenu>
+             </contextMenu>
             </TreeTableView>
             <VBox prefHeight="200.0" prefWidth="100.0">
                <children>

--- a/src/main/resources/logbook/gui/config.fxml
+++ b/src/main/resources/logbook/gui/config.fxml
@@ -158,6 +158,7 @@
                               <RowConstraints prefHeight="30.0" vgrow="SOMETIMES" />
                               <RowConstraints prefHeight="30.0" vgrow="SOMETIMES" />
                               <RowConstraints prefHeight="30.0" vgrow="SOMETIMES" />
+                              <RowConstraints prefHeight="30.0" vgrow="SOMETIMES" />
                            </rowConstraints>
                            <children>
                               <CheckBox fx:id="visibleExpGauge" mnemonicParsing="false" text="艦娘の画像に経験値バーを表示する" GridPane.columnSpan="3" />
@@ -170,8 +171,9 @@
                               <Label text="画像の拡大・縮小(%)" GridPane.rowIndex="3" />
                               <TextField fx:id="imageZoomRate" prefWidth="60.0" GridPane.columnIndex="1" GridPane.rowIndex="3" />
                               <Label text="(一部の一覧表示にのみ適用)" GridPane.columnIndex="2" GridPane.rowIndex="3" />
-                              <CheckBox fx:id="deckTabs" mnemonicParsing="false" text="所有艦娘一覧に艦隊単位のタブを追加" GridPane.columnSpan="2147483647" GridPane.rowIndex="4" />
-                              <CheckBox fx:id="labelTabs" mnemonicParsing="false" text="所有艦娘一覧にラベル単位のタブを追加" GridPane.columnSpan="2147483647" GridPane.rowIndex="5" />
+                              <CheckBox fx:id="allDecksTab" mnemonicParsing="false" text="所有艦娘一覧に全艦隊のタブを追加" GridPane.columnSpan="2147483647" GridPane.rowIndex="4" />
+                              <CheckBox fx:id="deckTabs" mnemonicParsing="false" text="所有艦娘一覧に艦隊単位のタブを追加" GridPane.columnSpan="2147483647" GridPane.rowIndex="5" />
+                              <CheckBox fx:id="labelTabs" mnemonicParsing="false" text="所有艦娘一覧にラベル単位のタブを追加" GridPane.columnSpan="2147483647" GridPane.rowIndex="6" />
                            </children>
                         </GridPane>
                         <Label styleClass="bold" text="艦隊タブの色" />

--- a/src/main/resources/logbook/gui/item_airbase.fxml
+++ b/src/main/resources/logbook/gui/item_airbase.fxml
@@ -2,6 +2,7 @@
 
 <?import javafx.scene.control.ChoiceBox?>
 <?import javafx.scene.control.ContextMenu?>
+<?import javafx.scene.control.Menu?>
 <?import javafx.scene.control.MenuItem?>
 <?import javafx.scene.control.SeparatorMenuItem?>
 <?import javafx.scene.control.Spinner?>
@@ -58,6 +59,12 @@
                     <MenuItem mnemonicParsing="false" onAction="#copyAirBase" text="クリップボードにコピー" />
                     <MenuItem mnemonicParsing="false" onAction="#selectAllAirBase" text="すべてを選択" />
                     <MenuItem mnemonicParsing="false" onAction="#storeAirBase" text="CSVファイルとして保存" />
+                    <SeparatorMenuItem mnemonicParsing="false" />
+                    <Menu mnemonicParsing="false" text="デッキビルダー形式（非公式）">
+                       <items>
+                          <MenuItem mnemonicParsing="false" onAction="#deckBuilderSelectionCopy" text="選択した機体をクリップボードにコピー" />
+                       </items>
+                    </Menu>
                     <SeparatorMenuItem mnemonicParsing="false" />
                     <MenuItem mnemonicParsing="false" onAction="#columnVisibleAirBase" text="列の表示・非表示" />
                  </items>

--- a/src/main/resources/logbook/gui/item_airbase.fxml
+++ b/src/main/resources/logbook/gui/item_airbase.fxml
@@ -17,8 +17,9 @@
     <children>
         <TitledPane fx:id="filter" animated="false" expanded="false" text="フィルター">
            <content>
-              <VBox>
+              <VBox spacing="5">
                  <children>
+                    <ToggleSwitch fx:id="disableGrouping" prefWidth="0.0" style="-fx-font-weight: bold;" text="同一装備、同一属性(改修値・熟練度)でグルーピングしない" />
                     <FlowPane fx:id="filters" />
                  </children>
               </VBox>

--- a/src/main/resources/logbook/gui/ship_table.fxml
+++ b/src/main/resources/logbook/gui/ship_table.fxml
@@ -144,6 +144,12 @@
                       <MenuItem mnemonicParsing="false" onAction="#kancolleFleetanalysis" text="ロックされてる艦娘データをクリップボードにコピー" />
                     </items>
                   </Menu>
+                  <Menu mnemonicParsing="false" text="デッキビルダー">
+                    <items>
+                      <MenuItem mnemonicParsing="false" onAction="#deckBuilderDisplayCopy" text="表示されている艦隊所属艦をクリップボードにコピー" />
+                      <MenuItem mnemonicParsing="false" onAction="#deckBuilderSelectionCopy" text="選択した艦隊所属艦のみクリップボードにコピー" />
+                    </items>
+                  </Menu>
                   <SeparatorMenuItem mnemonicParsing="false" />
                <MenuItem mnemonicParsing="false" onAction="#columnVisible" text="列の表示・非表示" />
              </items>

--- a/src/main/resources/logbook/gui/ship_table.fxml
+++ b/src/main/resources/logbook/gui/ship_table.fxml
@@ -139,6 +139,11 @@
                         <MenuItem mnemonicParsing="false" onAction="#kanmusuListSelectionCopy" text="選択した艦のみクリップボードにコピー" />
                     </items>
                   </Menu>
+                  <Menu mnemonicParsing="false" text="艦隊分析">
+                    <items>
+                      <MenuItem mnemonicParsing="false" onAction="#kancolleFleetanalysis" text="ロックされてる艦娘データをクリップボードにコピー" />
+                    </items>
+                  </Menu>
                   <SeparatorMenuItem mnemonicParsing="false" />
                <MenuItem mnemonicParsing="false" onAction="#columnVisible" text="列の表示・非表示" />
              </items>


### PR DESCRIPTION
#### 変更内容
デッキビルダー形式の出力サポートを行った。デッキビルダーは基本的に艦隊所属艦の情報のみを必要とするため、所有艦娘のビューで表示されている艦のうち何れかの艦隊に所属している艦の情報を（その艦隊中の位置で）出力するように実装した。メニューは２つ：
1. 表示されている艦隊所属艦をクリップボードにコピー
1. 選択した艦隊所属艦のみクリップボードにコピー

1のほうは現在そのタブに表示されてる全ての艦娘のうち艦隊に所属している艦娘を、2のほうはそのテーブルにおいて選択されている艦娘のうち艦隊に所属している艦娘をデータに含めるようにした。つまり、全艦娘のタブで1を選択してデータを生成すれば、現状の第一艦隊から第四艦隊までの全てのデータが生成される。特定の艦隊のみ生成したい場合はそれらの艦隊に属する艦娘のみを選択して2を実行すればよい。

関連して、例えば連合艦隊時に第一艦隊と第二艦隊だけデータを生成したい場合があるのを想定し、艦隊所属艦のみを表示できるタブを用意した。設定から「所有艦娘一覧に全艦隊のタブを追加」を選択すれば表示されるようになる。このタブを利用して第一艦隊と第二艦隊に所属している艦娘を選択し、2を実行すれば第二艦隊までの情報が生成される。

また、[艦隊分析](https://kancolle-fleetanalysis.firebaseapp.com/#/)さんへの艦娘データ入力をサポートした。こちらは全艦娘のデータが必要なので、（テーブル上での選択等は関係なく）すべてのロックされている艦娘のデータをクリップボードにコピー可能とした。

所有艦娘のビューで前回開いていたタブの情報が記憶されていなかったので記憶するように変更した。また、所有装備の基地航空隊タブで同一装備・同一属性（改修値・熟練度）でグルーピングしないオプションも同時に実装した。

デッキビルダー形式については以下のサイトで正常に取り込まれることを確認した：
- [艦隊シミュレータ＆デッキビルダー](http://kancolle-calc.net/deckbuilder.html)さん
- [作戦室 Jervis OR](https://kcjervis.github.io/jervis/#/)さん
- [制空権シミュレータ](https://noro6.github.io/kcTools/)さん
#### 関連するIssue
Fixes #197

