### PR TITLE
艦娘の素の値の計算間違いを修正 #217

### DIFF
--- a/src/main/java/logbook/internal/gui/ShipItem.java
+++ b/src/main/java/logbook/internal/gui/ShipItem.java
@@ -965,9 +965,9 @@ public class ShipItem {
         Ships.shipMst(ship).filter(s -> ship.getKyouka() != null && ship.getKyouka().size() >= 5).ifPresent((mst) -> {
             Optional.ofNullable(mst.getHoug()).filter(list -> list != null && list.size() > 0).map(list -> list.get(0) + ship.getKyouka().get(0)).ifPresent(shipItem::setKaryoku);
             Optional.ofNullable(mst.getRaig()).filter(list -> list != null && list.size() > 0).map(list -> list.get(0) + ship.getKyouka().get(1)).ifPresent(shipItem::setRaisou);
-            Optional.ofNullable(mst.getTaik()).filter(list -> list != null && list.size() > 0).map(list -> list.get(0) + ship.getKyouka().get(2)).ifPresent(shipItem::setTaiku);
-            Optional.ofNullable(mst.getSouk()).filter(list -> list != null && list.size() > 0).map(list -> list.get(0) + ship.getKyouka().get(3)).ifPresent(shipItem::setTaiku);
-            Optional.ofNullable(mst.getLuck()).filter(list -> list != null && list.size() > 0).map(list -> list.get(0) + ship.getKyouka().get(4)).ifPresent(shipItem::setTaiku);
+            Optional.ofNullable(mst.getTyku()).filter(list -> list != null && list.size() > 0).map(list -> list.get(0) + ship.getKyouka().get(2)).ifPresent(shipItem::setTaiku);
+            Optional.ofNullable(mst.getSouk()).filter(list -> list != null && list.size() > 0).map(list -> list.get(0) + ship.getKyouka().get(3)).ifPresent(shipItem::setSoukou);
+            Optional.ofNullable(mst.getLuck()).filter(list -> list != null && list.size() > 0).map(list -> list.get(0) + ship.getKyouka().get(4)).ifPresent(shipItem::setLucky);
         });
 
         // 以下の対潜・索敵・回避は定義からでは計算できない


### PR DESCRIPTION
#### 問題解析
所有艦娘ビューでの素の値の計算部分でコピペミスにより対空・装甲・運の値が全部対空にセットされていて結果的に対空は運の値、装甲・運は古い計算方法（現在の値-装備による増分）で計算するようになっていた。

#### 変更内容
正しい項目にセットするように修正。また確認中に定義上の対空値を `api_taik` （耐久）を参照していたことも判明したので正しいもの（`api_tyku`）に修正。

#### 関連するIssue
Fixes #217 

