### PR TITLE
所有艦娘一覧の全員タブのソート順を艦これの艦種ソートに合わせる

### DIFF
--- a/src/main/java/logbook/bean/ShipMst.java
+++ b/src/main/java/logbook/bean/ShipMst.java
@@ -27,6 +27,9 @@ public class ShipMst implements Serializable {
     /** 図鑑番号 */
     private Integer sortno;
 
+    /** ソート順 */
+    private Integer sortId;
+
     /** 名前 */
     private String name;
 
@@ -183,6 +186,7 @@ public class ShipMst implements Serializable {
         JsonHelper.bind(json)
                 .setInteger("api_id", bean::setId)
                 .setInteger("api_sortno", bean::setSortno)
+                .setInteger("api_sort_id", bean::setSortId)
                 .setString("api_name", bean::setName)
                 .setString("api_yomi", bean::setYomi)
                 .setInteger("api_stype", bean::setStype)

--- a/src/main/java/logbook/internal/gui/ShipController.java
+++ b/src/main/java/logbook/internal/gui/ShipController.java
@@ -24,8 +24,10 @@ import logbook.bean.DeckPortCollection;
 import logbook.bean.Ship;
 import logbook.bean.ShipCollection;
 import logbook.bean.ShipLabelCollection;
+import logbook.bean.ShipMst;
 import logbook.internal.LoggerHolder;
 import logbook.internal.SeaArea;
+import logbook.internal.Ships;
 
 /**
  * 所有艦娘一覧のコントローラ
@@ -64,8 +66,10 @@ public class ShipController extends WindowController {
                 Map<Integer, Ship> shipMap = ShipCollection.get()
                         .getShipMap();
                 return shipMap.values().stream()
-                        .sorted(Comparator.comparing(Ship::getLv).reversed()
-                                .thenComparing(Comparator.comparing(Ship::getShipId)))
+//                      .sorted(Comparator.comparing(Ship::getLv).reversed()
+//                      .thenComparing(Comparator.comparing(Ship::getShipId)))
+                        .sorted(Comparator.comparingInt((Ship s) -> Ships.shipMst(s).map(ShipMst::getSortId).orElse(Integer.MAX_VALUE))
+                                .thenComparingInt(Ship::getId))
                         .collect(Collectors.toList());
             }, "全員");
 


### PR DESCRIPTION
#### 変更内容
所有艦娘一覧の全員タブのソート順はこれまでレベルの降順、艦種IDの昇順なので実質レベルソートとほぼ同じ挙動になっていたが、艦これ本体の艦種ソート順と同じソート順は実現できていなかったので、全員タブのデフォルトソート順を艦これの艦種ソートと同じにする。

