### PR TITLE
同じクラスのウィンドウ位置・サイズを複数記憶する #214

### DIFF
--- a/src/main/java/logbook/internal/gui/InternalFXMLLoader.java
+++ b/src/main/java/logbook/internal/gui/InternalFXMLLoader.java
@@ -77,6 +77,24 @@ public final class InternalFXMLLoader {
     static void showWindow(String name, Stage parent, String title, Function<Parent, Scene> sceneFunction,
             Consumer<WindowController> controllerConsumer,
             Consumer<Stage> windowConsumer) throws IOException {
+        showWindow(name, parent, title, null, sceneFunction, controllerConsumer, windowConsumer);
+    }
+
+    /**
+     * ウインドウを開く
+     *
+     * @param name リソース
+     * @param parent 親ウインドウ
+     * @param title ウインドウタイトル
+     * @param subkey 同じクラスでウィンドウ位置の保存を分けたいときに使うキー
+     * @param sceneFunction シーン・グラフを操作するFunction
+     * @param controllerConsumer コントローラーを操作するConsumer
+     * @param windowConsumer ウインドウを操作するConsumer
+     * @throws IOException 入出力例外が発生した場合
+     */
+    static void showWindow(String name, Stage parent, String title, String subkey, Function<Parent, Scene> sceneFunction,
+            Consumer<WindowController> controllerConsumer,
+            Consumer<Stage> windowConsumer) throws IOException {
 
         FXMLLoader loader = load(name);
         Stage stage = new Stage();
@@ -100,8 +118,8 @@ public final class InternalFXMLLoader {
         stage.initOwner(parent);
         stage.setTitle(title);
         Tools.Windows.setIcon(stage);
-        Tools.Windows.defaultCloseAction(controller);
-        Tools.Windows.defaultOpenAction(controller);
+        Tools.Windows.defaultCloseAction(controller, subkey);
+        Tools.Windows.defaultOpenAction(controller, subkey);
         stage.show();
     }
 }

--- a/src/main/java/logbook/internal/gui/Main.java
+++ b/src/main/java/logbook/internal/gui/Main.java
@@ -58,7 +58,7 @@ public class Main extends Application {
                         .put(controller.getClass().getCanonicalName(), controller.getWindowLocation());
             }
         });
-        Tools.Windows.defaultOpenAction(controller);
+        Tools.Windows.defaultOpenAction(controller, null);
 
         stage.show();
     }

--- a/src/main/java/logbook/internal/gui/MainMenuController.java
+++ b/src/main/java/logbook/internal/gui/MainMenuController.java
@@ -134,7 +134,7 @@ public class MainMenuController extends WindowController {
             if (log != null && log.getBattle() != null) {
                 BattleLog sendlog = log;
                 InternalFXMLLoader.showWindow("logbook/gui/battle_detail.fxml", this.parentController.getWindow(),
-                        "演習詳細", c -> {
+                        "演習詳細", "practice", null, c -> {
                             ((BattleDetail) c).setInterval(() -> AppCondition.get().getPracticeBattleResult());
                             ((BattleDetail) c).setData(sendlog);
                         }, null);

--- a/src/main/java/logbook/internal/gui/Tools.java
+++ b/src/main/java/logbook/internal/gui/Tools.java
@@ -101,10 +101,10 @@ public class Tools {
          * デフォルトの閉じるアクション
          * @param controller WindowController
          */
-        public static void defaultCloseAction(WindowController controller) {
+        public static void defaultCloseAction(WindowController controller, String subkey) {
             if (controller.getWindow() != null) {
                 EventHandler<WindowEvent> action = e -> {
-                    String key = controller.getClass().getCanonicalName();
+                    String key = controller.getClass().getCanonicalName()+ Optional.ofNullable(subkey).map(str -> "#"+ str).orElse("");
                     AppConfig.get()
                             .getWindowLocationMap()
                             .put(key, controller.getWindowLocation());
@@ -118,8 +118,8 @@ public class Tools {
          * デフォルトのウインドウ設定
          * @param controller WindowController
          */
-        public static void defaultOpenAction(WindowController controller) {
-            String key = controller.getClass().getCanonicalName();
+        public static void defaultOpenAction(WindowController controller, String subkey) {
+            String key = controller.getClass().getCanonicalName() + Optional.ofNullable(subkey).map(str -> "#"+ str).orElse("");
             WindowLocation location = AppConfig.get()
                     .getWindowLocationMap()
                     .get(key);


### PR DESCRIPTION
#### 問題解析
演習詳細も戦闘詳細のように表示できるようにしているが、同じクラスを使っているためウィンドウの位置・サイズは同一の情報となっているので #214 に示されたような挙動となっている。

#### 変更内容
FXML をロードするときに、クラス名がキーとなっているところに副キーを指定できるように変更し、既に戦闘詳細用で保持している情報を壊さないように演習詳細時にのみ副キーを指定して別に記憶できるようにした。

#### 関連するIssue
#214 

