### PR TITLE
Colorado特殊攻撃、僚艦夜戦突撃に対応 #226

### DIFF
--- a/src/main/java/logbook/bean/BattleTypes.java
+++ b/src/main/java/logbook/bean/BattleTypes.java
@@ -1590,7 +1590,9 @@ public class BattleTypes {
         戦爆連合CI("戦爆連合CI"),
         NelsonTouch("NelsonTouch"),
         胸熱CI("一斉射かッ…胸が熱いな！"),
-        陸奥タッチ("長門、いい？ いくわよ！ 主砲一斉射ッ！");
+        陸奥タッチ("長門、いい？ いくわよ！ 主砲一斉射ッ！"),
+        ColoradoTouch("特殊攻撃(Colorado)"),
+        僚艦夜戦突撃("僚艦夜戦突撃");   // 夜戦専用だが念のため
 
         private String name;
 
@@ -1627,6 +1629,10 @@ public class BattleTypes {
                 return 胸熱CI;
             case 102:
                 return 陸奥タッチ;
+            case 103:
+                return ColoradoTouch;
+            case 104:
+                return 僚艦夜戦突撃;
             default:
                 return 通常攻撃;
             }
@@ -1657,7 +1663,9 @@ public class BattleTypes {
         魚雷見張員電探CI("魚雷見張員電探CI"),
         NelsonTouch("NelsonTouch"),
         胸熱CI("一斉射かッ…胸が熱いな！"),
-        陸奥タッチ("長門、いい？ いくわよ！ 主砲一斉射ッ！");
+        陸奥タッチ("長門、いい？ いくわよ！ 主砲一斉射ッ！"),
+        ColoradoTouch("特殊攻撃(Colorado)"),
+        僚艦夜戦突撃("僚艦夜戦突撃");
 
         private String name;
 
@@ -1696,6 +1704,10 @@ public class BattleTypes {
                 return 胸熱CI;
             case 102:
                 return 陸奥タッチ;
+            case 103:
+                return ColoradoTouch;
+            case 104:
+                return 僚艦夜戦突撃;
             default:
                 return 通常攻撃;
             }

--- a/src/main/java/logbook/internal/PhaseState.java
+++ b/src/main/java/logbook/internal/PhaseState.java
@@ -578,6 +578,12 @@ public class PhaseState {
                         .map(l -> l.get(index))
                         .map(MidnightSpList::toMidnightSpList)
                         .orElse(MidnightSpList.toMidnightSpList(0));
+                // 僚艦夜戦突撃が連合艦隊で発動すると、なぜか at_list の艦が0（本隊旗艦）を指すため
+                // そのままだと本隊の一番艦が攻撃したかのような表示になってしまう。
+                // 恐らく艦これ側のバグなのでいつか修正されることを想定して連合艦隊でかつ index が0の場合のみ対応しておく。
+                if (atType == MidnightSpList.僚艦夜戦突撃 && at == 0 && at < this.afterFriendCombined.size()) {
+                    at += 6;
+                }
             } else {
                 atType = Optional.ofNullable(hougeki.getAtType())
                         .map(l -> l.get(index))


### PR DESCRIPTION
#### 問題解析
Colorado特殊攻撃、僚艦夜戦突撃が発動しても、「通常攻撃」として表示される。これは単に陸奥タッチ実装以後のIDに対応していないため。しかし #226 にあるように、連合艦隊で僚艦夜戦突撃が発動した場合なぜか第一艦隊の旗艦が攻撃したことになっている。これは `at_list` にある番号がなぜか0（第二の旗艦なら本来は6）で送られてきているため。おそらく艦これのバグと思われる（そもそも艦これ本体でも第一艦隊によるカットインが表示されるバグがあり、それが直された経緯があるが、その際に恐らくクライアント側で対応したと考えられる）。

#### 変更内容
まず新しい特殊攻撃については定義を追加する。上記の艦これのバグについては、将来修正されることも考えられるので、まず index が 0 でかつ連合艦隊である場合にのみこちら側で補正するようにした。

#### 関連するIssue
#226 

