### PR TITLE
第二艦隊の旗艦の大破警告を抑制するオプション #227

### DIFF
--- a/src/main/java/logbook/api/ApiReqMapNext.java
+++ b/src/main/java/logbook/api/ApiReqMapNext.java
@@ -73,7 +73,7 @@ public class ApiReqMapNext implements APIListenerSpi {
                 if (condition.isCombinedFlag()) {
                     badlyShips.addAll(DeckPortCollection.get()
                             .getDeckPortMap()
-                            .get(2).getBadlyShips());
+                            .get(2).getBadlyShips(AppConfig.get().isIgnoreSecondFlagship()));
                 }
 
                 if (!badlyShips.isEmpty()) {

--- a/src/main/java/logbook/api/ApiReqMapStart.java
+++ b/src/main/java/logbook/api/ApiReqMapStart.java
@@ -71,7 +71,7 @@ public class ApiReqMapStart implements APIListenerSpi {
                 if (AppCondition.get().isCombinedFlag()) {
                     badlyShips.addAll(DeckPortCollection.get()
                             .getDeckPortMap()
-                            .get(2).getBadlyShips());
+                            .get(2).getBadlyShips(AppConfig.get().isIgnoreSecondFlagship()));
                 }
 
                 if (!badlyShips.isEmpty()) {

--- a/src/main/java/logbook/bean/AppConfig.java
+++ b/src/main/java/logbook/bean/AppConfig.java
@@ -36,6 +36,9 @@ public final class AppConfig implements Serializable {
     /** 進撃時に大破艦がいる場合に通知をする */
     private boolean alertBadlyNext = true;
 
+    /** 第二艦隊の旗艦の大破は通知しない */
+    private boolean ignoreSecondFlagship = false;
+
     /** 通知でサウンドを鳴らす */
     private boolean useSound = true;
 

--- a/src/main/java/logbook/bean/DeckPort.java
+++ b/src/main/java/logbook/bean/DeckPort.java
@@ -54,10 +54,20 @@ public class DeckPort implements Serializable, Cloneable {
      */
     @JsonIgnore
     public List<Ship> getBadlyShips() {
+        return getBadlyShips(false);
+    }
+    
+    /**
+     * 大破した艦娘を返します
+     *
+     * @return 大破した艦娘
+     */
+    public List<Ship> getBadlyShips(boolean ignoreFlagship) {
         Map<Integer, Ship> shipMap = ShipCollection.get().getShipMap();
         return this.getShip()
                 .stream()
                 .map(shipMap::get)
+                .skip(ignoreFlagship ? 1:0)
                 .filter(Objects::nonNull)
                 .filter(Ships::isBadlyDamage)
                 .filter(s -> !Ships.isEscape(s))

--- a/src/main/java/logbook/internal/gui/ConfigController.java
+++ b/src/main/java/logbook/internal/gui/ConfigController.java
@@ -100,6 +100,10 @@ public class ConfigController extends WindowController {
     @FXML
     private CheckBox alertBadlyNext;
 
+    /** 大破警告から第二艦隊旗艦を除外する */
+    @FXML
+    private CheckBox ignoreSecondFlagship;
+
     /** 通知でサウンドを鳴らす */
     @FXML
     private CheckBox useSound;
@@ -375,6 +379,7 @@ public class ConfigController extends WindowController {
         this.useNotification.setSelected(conf.isUseNotification());
         this.alertBadlyStart.setSelected(conf.isAlertBadlyStart());
         this.alertBadlyNext.setSelected(conf.isAlertBadlyNext());
+        this.ignoreSecondFlagship.setSelected(conf.isIgnoreSecondFlagship());
         this.useSound.setSelected(conf.isUseSound());
         this.defaultNotifySound.setText(conf.getDefaultNotifySound());
         this.useToast.setSelected(conf.isUseToast());
@@ -498,6 +503,7 @@ public class ConfigController extends WindowController {
         conf.setUseNotification(this.useNotification.isSelected());
         conf.setAlertBadlyStart(this.alertBadlyStart.isSelected());
         conf.setAlertBadlyNext(this.alertBadlyNext.isSelected());
+        conf.setIgnoreSecondFlagship(this.ignoreSecondFlagship.isSelected());
         conf.setUseSound(this.useSound.isSelected());
         conf.setDefaultNotifySound(this.defaultNotifySound.getText());
         conf.setUseToast(this.useToast.isSelected());

--- a/src/main/resources/logbook/gui/config.fxml
+++ b/src/main/resources/logbook/gui/config.fxml
@@ -41,16 +41,17 @@
                           <rowConstraints>
                               <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
                               <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                            <RowConstraints minHeight="10.0" prefHeight="24.0" vgrow="SOMETIMES" />
+                              <RowConstraints minHeight="10.0" prefHeight="24.0" vgrow="SOMETIMES" />
                               <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
                               <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
                               <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
                               <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
                               <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
                               <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                            <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
                               <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                            <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                              <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                              <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                              <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
                               <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
                               <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
                               <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
@@ -85,24 +86,25 @@
                               </HBox>
                               <CheckBox fx:id="alertBadlyStart" mnemonicParsing="false" text="出撃時に大破艦がいる場合に通知をする" GridPane.columnSpan="2147483647" GridPane.rowIndex="3" />
                               <CheckBox fx:id="alertBadlyNext" mnemonicParsing="false" text="進撃時に大破艦がいる場合に通知をする" GridPane.columnSpan="2147483647" GridPane.rowIndex="4" />
-                              <CheckBox fx:id="useSound" mnemonicParsing="false" text="通知でサウンドを鳴らす" GridPane.columnSpan="2147483647" GridPane.rowIndex="5" />
-                              <Label text="デフォルトサウンド" GridPane.rowIndex="6" />
-                              <TextField fx:id="defaultNotifySound" prefWidth="200.0" GridPane.columnIndex="1" GridPane.rowIndex="6" />
-                              <Button mnemonicParsing="false" onAction="#selectSoundFile" text="参照..." GridPane.columnIndex="2" GridPane.rowIndex="6" />
-                              <Label text="トーストの位置" GridPane.rowIndex="7" />
-                              <ChoiceBox fx:id="toastLocation" prefWidth="60.0" GridPane.columnIndex="1"  GridPane.rowIndex="7" />
-                              <CheckBox fx:id="useRemind" mnemonicParsing="false" text="遠征完了時のリマインド(秒)" GridPane.rowIndex="8" />
-                              <TextField fx:id="remind" prefWidth="60.0" GridPane.columnIndex="1" GridPane.rowIndex="8" />
-                              <Label text="音量(%)" GridPane.rowIndex="9" />
-                              <TextField fx:id="soundLevel" prefWidth="60.0" GridPane.columnIndex="1" GridPane.rowIndex="9" />
-                              <Label text="資材ログ保存間隔(秒)" GridPane.rowIndex="10" />
-                              <TextField fx:id="materialLogInterval" prefWidth="60.0" GridPane.columnIndex="1" GridPane.rowIndex="10" />
-                              <CheckBox fx:id="onTop" mnemonicParsing="false" text="最前面に表示する*" GridPane.columnSpan="2147483647" GridPane.rowIndex="11" />
-                              <CheckBox fx:id="checkDoit" mnemonicParsing="false" text="終了時に確認する" GridPane.rowIndex="12" />
-                              <CheckBox fx:id="checkUpdate" mnemonicParsing="false" text="起動時にアップデートチェック*" GridPane.columnSpan="2147483647" GridPane.rowIndex="13" />
-                              <Label text="報告書の保存先" GridPane.rowIndex="14" />
-                              <TextField fx:id="reportDir" prefWidth="200.0" GridPane.columnIndex="1" GridPane.rowIndex="14" />
-                              <Button mnemonicParsing="false" onAction="#selectReportDir" text="参照..." GridPane.columnIndex="2" GridPane.rowIndex="14" />
+                              <CheckBox fx:id="ignoreSecondFlagship" mnemonicParsing="false" text="大破警告から連合艦隊の第二艦隊旗艦を除外する" GridPane.columnSpan="2147483647" GridPane.rowIndex="5" />
+                              <CheckBox fx:id="useSound" mnemonicParsing="false" text="通知でサウンドを鳴らす" GridPane.columnSpan="2147483647" GridPane.rowIndex="6" />
+                              <Label text="デフォルトサウンド" GridPane.rowIndex="7" />
+                              <TextField fx:id="defaultNotifySound" prefWidth="200.0" GridPane.columnIndex="1" GridPane.rowIndex="7" />
+                              <Button mnemonicParsing="false" onAction="#selectSoundFile" text="参照..." GridPane.columnIndex="2" GridPane.rowIndex="7" />
+                              <Label text="トーストの位置" GridPane.rowIndex="8" />
+                              <ChoiceBox fx:id="toastLocation" prefWidth="60.0" GridPane.columnIndex="1"  GridPane.rowIndex="8" />
+                              <CheckBox fx:id="useRemind" mnemonicParsing="false" text="遠征完了時のリマインド(秒)" GridPane.rowIndex="9" />
+                              <TextField fx:id="remind" prefWidth="60.0" GridPane.columnIndex="1" GridPane.rowIndex="9" />
+                              <Label text="音量(%)" GridPane.rowIndex="10" />
+                              <TextField fx:id="soundLevel" prefWidth="60.0" GridPane.columnIndex="1" GridPane.rowIndex="10" />
+                              <Label text="資材ログ保存間隔(秒)" GridPane.rowIndex="11" />
+                              <TextField fx:id="materialLogInterval" prefWidth="60.0" GridPane.columnIndex="1" GridPane.rowIndex="11" />
+                              <CheckBox fx:id="onTop" mnemonicParsing="false" text="最前面に表示する*" GridPane.columnSpan="2147483647" GridPane.rowIndex="12" />
+                              <CheckBox fx:id="checkDoit" mnemonicParsing="false" text="終了時に確認する" GridPane.rowIndex="13" />
+                              <CheckBox fx:id="checkUpdate" mnemonicParsing="false" text="起動時にアップデートチェック*" GridPane.columnSpan="2147483647" GridPane.rowIndex="14" />
+                              <Label text="報告書の保存先" GridPane.rowIndex="15" />
+                              <TextField fx:id="reportDir" prefWidth="200.0" GridPane.columnIndex="1" GridPane.rowIndex="15" />
+                              <Button mnemonicParsing="false" onAction="#selectReportDir" text="参照..." GridPane.columnIndex="2" GridPane.rowIndex="15" />
                            </children>
                         </GridPane>
                      </children>


### PR DESCRIPTION
#### 変更内容
今のところの艦これの挙動において、連合艦隊時に第二艦隊の旗艦が大破しても以降の進撃で轟沈することはないと考えられている。なので logbook-kai における大破進撃警告が実際にはあまり意味をなさず、逆に第二艦隊の旗艦以外も大破している場合に警告を無視してしまうリスクもあるため警告を抑制するオプションには意味があると考えられ、そのように実装を行なった。ただしこれは明確に宣言されている仕様ではないためいつ変更されるか不明なため、デフォルトは第二艦隊の旗艦であっても大破警告を行うほうにしておく。

#### 関連するIssue
#227 

