### PR TITLE
遠征条件の対潜値計算方法の変更

### DIFF
--- a/src/main/java/logbook/bean/MissionCondition.java
+++ b/src/main/java/logbook/bean/MissionCondition.java
@@ -158,7 +158,7 @@ public class MissionCondition implements TestAllPredicate<List<Ship>> {
             current = this.fleetStatus(ships, ship -> ship.getKaryoku().get(0));
         }
         if ("対潜".equals(this.countType)) {
-            current = this.fleetStatus(ships, ship -> ship.getTaisen().get(0));
+            current = this.fleetStatus(ships , ship -> Ships.getTaisen(ship) + Ships.sumItemParam(ship, SlotitemMst::getTais, true));
         }
         if ("対空".equals(this.countType)) {
             current = this.fleetStatus(ships, ship -> ship.getTaiku().get(0));

--- a/src/main/java/logbook/internal/ImageListener.java
+++ b/src/main/java/logbook/internal/ImageListener.java
@@ -58,7 +58,11 @@ public class ImageListener implements ContentListenerSpi {
             }
             // 汎用画像
             if (uri.startsWith("/kcs2/img/common/")) {
-                this.common(request, response);
+                this.images(request, response, "common");
+            }
+            // 任務関連画像
+            if (uri.startsWith("/kcs2/img/duty/")) {
+                this.images(request, response, "duty");
             }
         } catch (Exception e) {
             LoggerHolder.get().warn("画像ファイル処理中に例外が発生しました", e);
@@ -114,9 +118,9 @@ public class ImageListener implements ContentListenerSpi {
         }
     }
 
-    private void common(RequestMetaData request, ResponseMetaData response) throws IOException {
+    private void images(RequestMetaData request, ResponseMetaData response, String dirname) throws IOException {
         String uri = request.getRequestURI();
-        Path dir = Paths.get(AppConfig.get().getResourcesDir(), "common");
+        Path dir = Paths.get(AppConfig.get().getResourcesDir(), dirname);
         Path path = dir.resolve(Paths.get(URI.create(uri).getPath()).getFileName());
         if (response.getResponseBody().isPresent()) {
             this.write(response.getResponseBody().get(), path);

--- a/src/main/java/logbook/internal/gui/ShipController.java
+++ b/src/main/java/logbook/internal/gui/ShipController.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javafx.animation.KeyFrame;
 import javafx.animation.Timeline;
@@ -158,7 +159,7 @@ public class ShipController extends WindowController {
                 })
                 .filter(Objects::nonNull)
                 .distinct()
-                .sorted()
+                .sorted(Comparator.comparing(ShipController::labelSortOrder))
                 .forEach(label -> {
                     ShipTablePane labelPane = new ShipTablePane(() -> {
                         Map<Integer, Ship> shipMap = ShipCollection.get()
@@ -179,6 +180,19 @@ public class ShipController extends WindowController {
                     }, label);
                     this.tab.getTabs().add(new Tab(label, labelPane));
                 });
+    }
+
+    /**
+     * ラベルのソート順を返します
+     * @param label ラベル文字列
+     * @return ソート順、もし定義にないものの場合は Integer.MAX_VALUE
+     */
+    private static int labelSortOrder(String label) {
+        return Stream.of(SeaArea.values())
+                .filter(s -> s.getName().equals(label))
+                .findAny()
+                .map(SeaArea::getArea)
+                .orElse(Integer.MAX_VALUE);
     }
 
     /**

--- a/src/main/resources/logbook/mission/7/44.json
+++ b/src/main/resources/logbook/mission/7/44.json
@@ -6,7 +6,7 @@
         {
             "operator": "AND",
             "conditions": [
-                {"type": "艦娘", "level": 60, "order": 1}
+                {"type": "艦娘", "level": 35, "order": 1}
             ]
         },
         {


### PR DESCRIPTION
#### 問題解析
#225 の報告によれば、搭載数0のスロットに艦載機を搭載した場合、遠征時の成功条件の対潜値の計算には含まれないとのこと。現状は単純に艦娘のステータス値（艦これ本体で表示される値と同じ）であるため、その場合 over estimate となり成功条件を誤る可能性がある。本来なら搭載数0の場合正味のステータス値が変化すべきであるが、現状の艦これの仕様はそうなっている模様。

#### 変更内容
対潜値の計算は複雑な計算式があると考えられ、そのまま厳密な計算式を実装することはメンテナンスコストの意味でも現実的でない。なので遠征の場合は under estimate 側に振った方がよい（過剰に装備を搭載することになるだけなので）ので、艦娘の素の対潜値に加えて装備の対潜値を加えることで対潜値の計算を行うようにする。火力等ほかのパラメータも同様に搭載数0の場合加算されないのかもしれないが、対潜値以外については今後の検証を待つ。

#### 関連するIssue
#225

