### PR TITLE
Z前段作戦の条件を修正 #232

### DIFF
--- a/src/main/resources/logbook/quest/854.json
+++ b/src/main/resources/logbook/quest/854.json
@@ -2,9 +2,9 @@
 {
     "resetType" : "クオータリー",
     "conditions" : [
-        {"boss": true, "area": ["2-4"], "rank": ["A"], "count": 1},
-        {"boss": true, "area": ["6-1"], "rank": ["A"], "count": 1},
-        {"boss": true, "area": ["6-3"], "rank": ["A"], "count": 1},
+        {"boss": true, "area": ["2-4"], "rank": ["S", "A"], "count": 1},
+        {"boss": true, "area": ["6-1"], "rank": ["S", "A"], "count": 1},
+        {"boss": true, "area": ["6-3"], "rank": ["S", "A"], "count": 1},
         {"boss": true, "area": ["6-4"], "rank": ["S"], "count": 1}
     ]
 }


### PR DESCRIPTION
#### 問題解析
Z前段作戦(854)の進捗カウントにおいて、S勝利だとカウントされないという現象が起きた。確認したところ本来「SまたはA」と指定すべきところが「A」のみの指定になっているためだった。

#### 変更内容
SまたはAに変更。報告があった2-4だけでなく、6-1、6-3も同様だった。6-1で問題の再現および修正の確認を行った。

#### 関連するIssue
#232

