### PR TITLE
リポジトリ変更に備えて自動更新等のURL変更及び告知

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@
 [![GitHub All Releases](https://img.shields.io/github/downloads/sanaehirotaka/logbook-kai/total)](https://github.com/sanaehirotaka/logbook-kai/releases)
 [![GitHub Release Date](https://img.shields.io/github/release-date/sanaehirotaka/logbook-kai)](https://github.com/sanaehirotaka/logbook-kai/releases)
 
+## ****重要なお知らせ****
+v20.9.2 以降のバージョンはオリジナルの [sanaehirotaka さんのリポジトリ](https://github.com/sanaehirotaka/logbook-kai/)ではなく
+[Sdk0815 の fork](https://github.com/Sdk0815/logbook-kai/)にて開発を行います。
+最新バージョンも[こちら](https://github.com/Sdk0815/logbook-kai/releases)からダウンロードしてください。
+今後は[Issue（問題報告・要望）](https://github.com/Sdk0815/logbook-kai/issues)や[Pull Request（変更要求）](https://github.com/Sdk0815/logbook-kai/pulls)などもそちらにオープンしていただきますようお願いします。
+
+### 概要
+
 **航海日誌 (logbook-kai)** は、「艦隊これくしょん ～艦これ～」をより遊びやすくするための外部ツールです。
 
 画面がコンパクトなのが特徴です。

--- a/src/main/java/logbook/internal/CheckUpdate.java
+++ b/src/main/java/logbook/internal/CheckUpdate.java
@@ -37,14 +37,17 @@ import logbook.internal.gui.Tools;
  */
 public class CheckUpdate {
 
+    /** GitHub リポジトリのパス */
+    public static final String REPOSITORY_PATH = "Sdk0815/logbook-kai";
+
     /** 更新確認先 Github tags API */
-    private static final String TAGS = "https://api.github.com/repos/sanaehirotaka/logbook-kai/tags";
+    private static final String TAGS = "https://api.github.com/repos/" + REPOSITORY_PATH + "/tags";
 
     /** 更新確認先 Github releases API */
-    private static final String RELEASES = "https://api.github.com/repos/sanaehirotaka/logbook-kai/releases/tags/";
+    private static final String RELEASES = "https://api.github.com/repos/" + REPOSITORY_PATH + "/releases/tags/";
 
     /** ダウンロードサイトを開くを選択したときに開くURL */
-    private static final String OPEN_URL = "https://github.com/sanaehirotaka/logbook-kai/releases";
+    private static final String OPEN_URL = "https://github.com/" + REPOSITORY_PATH + "/releases";
 
     /** 検索するtagの名前 */
     /* 例えばv20.1.1 の 20.1.1にマッチ */

--- a/src/main/java/logbook/internal/gui/VersionController.java
+++ b/src/main/java/logbook/internal/gui/VersionController.java
@@ -19,6 +19,7 @@ import javafx.scene.control.TextArea;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.Pane;
 import javafx.stage.Stage;
+import logbook.internal.CheckUpdate;
 import logbook.internal.LoggerHolder;
 import logbook.internal.ThreadManager;
 import logbook.internal.Version;
@@ -76,7 +77,7 @@ public class VersionController extends WindowController {
             ThreadManager.getExecutorService()
                     .submit(() -> {
                         Desktop.getDesktop()
-                                .browse(URI.create("https://github.com/sanaehirotaka/logbook-kai/releases"));
+                                .browse(URI.create("https://github.com/" + CheckUpdate.REPOSITORY_PATH + "/releases"));
                         return null;
                     });
         } catch (Exception e) {
@@ -90,7 +91,7 @@ public class VersionController extends WindowController {
             ThreadManager.getExecutorService()
                     .submit(() -> {
                         Desktop.getDesktop()
-                                .browse(URI.create("https://github.com/sanaehirotaka/logbook-kai/issues"));
+                                .browse(URI.create("https://github.com/" + CheckUpdate.REPOSITORY_PATH + "/issues"));
                         return null;
                     });
         } catch (Exception e) {

--- a/src/main/resources/logbook/update/update.js
+++ b/src/main/resources/logbook/update/update.js
@@ -31,7 +31,7 @@ var version = System.getProperty("install_version");
 // Prerelease を使うかどうか
 var usePrerelease = System.getProperty("use_prerelease");
 // GitHub Releases API
-var releaseURL = "https://api.github.com/repos/sanaehirotaka/logbook-kai/releases/tags/v" + version;
+var releaseURL = "https://api.github.com/repos/Sdk0815/logbook-kai/releases/tags/v" + version;
 var release = {};
 var asset = {};
 


### PR DESCRIPTION
#### 変更内容
メインの開発を引き継いで３ヶ月程度経過し、期間限定イベントの時期も無事超えることができたため、開発リポジトリをオリジナルの sanaehirotaka さんのところから @Sdk0815 の fork へと変更する。この PR では

- 自動更新の差し先を変更
- バージョン情報のリンクの差し先を変更
- README.md の先頭に変更告知を記載

の変更をカバーする。最新の `v20.9.1` は当然元のリポジトリを差しているため次のバージョンは以前と同様にこちらに公開する必要があるが、その `v20.9.2` が指す先は Sdk0815 のものを指すためその次のバージョンからはそちらにだけ公開すればよいはず。`v20.9.2` をリリースした後に残りに種々のリンク先の変更等を行なって完了とする。

#### 関連するIssue
N/A

